### PR TITLE
Add utility script to get service catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ A framework for counting the recommender metrics
 # Usage
 7. Run from terminal: `./preprocessor.py` in order to prepare the data for the RSmetrics
 8. Run from terminal: `./rsmetrics.py` to run RSmetrics
+
+## Utilities
+
+### Get service catalog script (./get_service_catalog.py)
+
+This script contacts EOSC Marketplace catalog and generates a csv with a list of all available services, their name, id and url
+
+To execute the script issue:
+```
+chmod u+x ./get_service_catalog.py
+./get_service_catalog.py
+```
+
+_Tested with python 3.9_

--- a/get_service_catalog.py
+++ b/get_service_catalog.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import requests
+from bs4 import BeautifulSoup
+import sys
+import csv
+import argparse
+
+
+
+# Main logic
+def main(args=None):
+    # call eosc marketplace with ample number of services per page: default = 1000
+    url = "https://marketplace.eosc-portal.eu/services?page=1&per_page={}".format(str(args.items))
+    
+    print("Retrieving page: marketplace list of services... \nGrabbing url: {0}".format(url))
+    page = requests.get(url)
+    
+    print("Page retrieved!\nGenerating results...")
+    soup = BeautifulSoup(page.content, 'html.parser')
+
+    # Find all h2 that contain the data-e2e attribute equal to service-id
+    results = soup.findAll("h2", {"data-e2e":"service-id"})
+    rows = []
+    # populate rows with each row = [service id, service name, service path]
+    for item in results:
+        a = item.findChildren("a",recursive=False)[0]
+        row = [int(item.attrs["data-service-id"]),item.text.strip(),a['href']]
+        rows.append(row)
+    # sort rows by id 
+    rows = sorted(rows, key=lambda x: x[0])
+    
+    # output to csv
+    with open(args.output, "w") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)
+    
+    print("File written to {}".format(args.output))
+
+
+# Parse arguments and call main 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Retrieve service catalog from eosc marketplace")
+    parser.add_argument(
+        "-n", "--num-of-items", metavar="STRING", help="Number of items per page", required=False, dest="items", default="1000")
+    parser.add_argument(
+        "-o", "--output", metavar="STRING", help="Output csv file", required=False, dest="output", default="./service_catalog.csv")
+
+    # Parse the arguments
+    sys.exit(main(parser.parse_args()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+beautifulsoup4==4.10.0
+certifi==2021.10.8
+charset-normalizer==2.0.12
+idna==3.3
+numpy==1.22.3
+pandas==1.4.2
+pymongo==4.1.0
+python-dateutil==2.8.2
+pytz==2022.1
+PyYAML==6.0
+requests==2.27.1
+six==1.16.0
+soupsieve==2.3.1
+urllib3==1.26.9


### PR DESCRIPTION
A simple utility script to grab all available services in EOSC Marketplace catalog and produce a csv with the following information about each service:
`service_id, service_name, service_url`
Records are sorted by service_id

This correlation is performed in a single request

Example execution time and cli output:
```
time ./get_service_catalog.py
Retrieving page: marketplace list of services...
Grabbing url: https://marketplace.eosc-portal.eu/services?page=1&per_page=1000
Page retrieved!
Generating results...
File written to ./service_catalog.csv
./get_service_catalog.py  0.76s user 0.07s system 6% cpu 12.368 total
```

Example output csv format:
```
1,EGI Cloud Compute,/services/egi-cloud-compute
2,EGI High-Throughput Compute,/services/egi-high-throughput-compute
3,EGI Cloud Container Compute,/services/egi-cloud-container-compute-beta
...
```