### PR TITLE
REC-69 Fix get services parsing due to changes in marketplace page structure

### DIFF
--- a/get_service_catalog.py
+++ b/get_service_catalog.py
@@ -50,7 +50,7 @@ def get_service_catalog_items(content):
     for item in results:
         a = item.findChildren("a", recursive=False)[0]
         row = [int(item.attrs["data-service-id"]),
-               item.text.strip(), a['href']]
+               a.text.strip(), a['href']]
         rows.append(row)
     # sort rows by id
     rows = sorted(rows, key=lambda x: x[0])


### PR DESCRIPTION
REC-69 Fix get services parsing due to changes in marketplace page structure

Since new text is included in the parent item get service title from anchor item itself