### PR TITLE
REC-24 Add the services rating info in the services.csv, as a second column in the CSV format file

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -253,13 +253,20 @@ if config['User']['export']:
 if config['Service']['export']:
 
     if config['Service']['from']=='page_map':
-        ss=natsorted(list(set(list(map(lambda x: x+'\n',values)))),alg=ns.ns.SIGNED)
+
+        _ss=natsorted(list(set(list(map(lambda x: x+'\n',values)))),alg=ns.ns.SIGNED)
+        ss=[]
+        for s in _ss:
+            try:
+                ss.append(s.strip()+','+recdb["service"].find({'_id':int(s)})[0]['rating']+'\n')
+            except:
+                continue
 
     else: # 'source'
         if config['Service']['published']:
-            ss=natsorted(list(set(list(map(lambda x: str(x['_id'])+'\n',recdb["service"].find({"status":"published"}))))),alg=ns.ns.SIGNED)
+            ss=natsorted(list(set(list(map(lambda x: str(x['_id'])+','+str(x['rating'])+'\n',recdb["service"].find({"status":"published"}))))),alg=ns.ns.SIGNED)
         else:
-            ss=natsorted(list(set(list(map(lambda x: str(x['_id'])+'\n',recdb["service"].find({}))))),alg=ns.ns.SIGNED)
+            ss=natsorted(list(set(list(map(lambda x: str(x['_id'])+','+str(x['rating'])+'\n',recdb["service"].find({}))))),alg=ns.ns.SIGNED)
 
     with open(os.path.join(args.output,'services.csv'), 'w') as o:
         o.writelines(ss)

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -93,7 +93,7 @@ else:
 run.users=pd.read_csv(os.path.join(args.input,'users.csv'),names=["User","Services"],converters={'Services': lambda x: map(int,x.split())})
     
 # populate services
-run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service"])
+run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Rating"])
 
 # remove user actions when user or service does not exist in users' or services' catalogs
 # adding -1 in all catalogs indicating the anonynoums users or not-known services


### PR DESCRIPTION
The new code:
- Supports a CSV format with two columns; the first column provides the service id while the second column provides the rating of the service.
- Rating is being retrieved from the Source (i.e. Mongo DB).
- The code, works for all config options of serving the services in services.csv.

If map_page is chosen (which is the default), it will try to find the rating in the Mongo DB. If not found, the service is withdrawn.