### PR TITLE
REC-75 Modifying services.csv file format to: service_id, rating, service_name,  service_page_id

### DIFF
--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -93,7 +93,7 @@ else:
 run.users=pd.read_csv(os.path.join(args.input,'users.csv'),names=["User","Services"],converters={'Services': lambda x: map(int,x.split())})
     
 # populate services
-run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Rating"])
+run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Rating", "Name", "Page"])
 
 # remove user actions when user or service does not exist in users' or services' catalogs
 # adding -1 in all catalogs indicating the anonynoums users or not-known services


### PR DESCRIPTION
This PR resolves REC-75.
The previous format of the `services.csv` file was containing lines in the form of:
service_id, rating

In order to create additional metrics in RS Metrics such as top_5_services_recommended, more info must be passed in the services.csv file.

So, the current format is changed to:
`service_id, rating, service_name, service_page_id`

- [x] Preprocessor produces the new format
- [x] RSMetrics is be able to parse it


Note: The service_page_id should be retrieved from the page_map. If no page_id can be retrieved, then the service is removed from the process.
