### PR TITLE
REC-76 Bugfix in dictionary creation of service ids and pages id

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -150,7 +150,7 @@ if config['Service']['download']:
 with open(os.path.join(args.output,config['Service']['path']), 'r') as f:
     lines=f.readlines()
 
-keys=list(map(lambda x: remove_service_prefix(x.split(',')[2]).strip(), lines))
+keys=list(map(lambda x: remove_service_prefix(x.split(',')[-1]).strip(), lines))
 values=list(map(lambda x: x.split(',')[0].strip(), lines))
 
 dmap=dict(zip(keys, values))  #=> {'a': 1, 'b': 2}

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -93,7 +93,7 @@ else:
 run.users=pd.read_csv(os.path.join(args.input,'users.csv'),names=["User","Services"],converters={'Services': lambda x: map(int,x.split())})
     
 # populate services
-run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Rating"])
+run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Rating", "Name", "Page"])
 
 # remove user actions when user or service does not exist in users' or services' catalogs
 # adding -1 in all catalogs indicating the anonynoums users or not-known services


### PR DESCRIPTION
This PR resolves bug in dictionary creation according to REC-76.

In the Preprocessor, a dictionary under the name "dmap" is created, where the keys are the service ids and the values are the respective page ids, retrieved from the page_map file.

Some services (i.e. 433, 434) have commas inside their name, breaking the format of the dictionary and consequently the services.csv file output.

It should retrieve the page_id from the last entry of the page_map file in order to bypass the fact that a service name might include commas in its name.
