### PR TITLE
REC-72 Top 5 services ordered metric is being added

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -150,7 +150,7 @@ if config['Service']['download']:
 with open(os.path.join(args.output,config['Service']['path']), 'r') as f:
     lines=f.readlines()
 
-keys=list(map(lambda x: remove_service_prefix(x.split(',')[2]).strip(), lines))
+keys=list(map(lambda x: remove_service_prefix(x.split(',')[-1]).strip(), lines))
 values=list(map(lambda x: x.split(',')[0].strip(), lines))
 
 dmap=dict(zip(keys, values))  #=> {'a': 1, 'b': 2}


### PR DESCRIPTION
This PR adds a new metric for the KPIs. The implementation calculates the Top 5 ordered services according to the recommendations entries.
User actions with Target Pages that lead to unknown services (=-1) are being ignored.
It returns a list of lists with the elements:
1. service id
2. service name
3. service page appended with base (to create the URL)
4. the total number of orders of the service
5. the percentage of the (iv) to the total number of orders expressed in %, with or without anonymous, based on the function's flag

Service's info is being retrieved from the services.csv file (i.e. each line forms: service_id, rating, service_name, page_id)