### PR TITLE
Sorting the metrics description fields in sidebar

### DIFF
--- a/webservice/templates/kpis.html
+++ b/webservice/templates/kpis.html
@@ -155,7 +155,7 @@
                                 </a>
                             </li>
                             <li class="app-sidebar__heading">Metrics Documentation</li>
-                            {%for key, item in data.sidebar_info.metric_descriptions.items() %}
+                            {%for key, item in data.sidebar_info.metric_descriptions.items() | sort %}
                             <li>
                                 <a href="/descriptions/metrics/{{key}}" {%if key==data.metric_active %}
                                     class="mm-active" {%endif%}>

--- a/webservice/templates/metric_desc.html
+++ b/webservice/templates/metric_desc.html
@@ -159,7 +159,7 @@
                                 </a>
                             </li>
                             <li class="app-sidebar__heading">Metrics Documentation</li>
-                            {%for key, item in data.sidebar_info.metric_descriptions.items() %}
+                            {%for key, item in data.sidebar_info.metric_descriptions.items() | sort %}
                             <li>
                                 <a href="/descriptions/metrics/{{key}}" {%if key == data.metric_active %} class="mm-active" {%endif%} >
                                     <i class="metismenu-icon {{item.style.icon}}"></i>

--- a/webservice/templates/rsmetrics.html
+++ b/webservice/templates/rsmetrics.html
@@ -155,7 +155,7 @@
                                 </a>
                             </li>
                             <li class="app-sidebar__heading">Metrics Documentation</li>
-                            {%for key, item in data.sidebar_info.metric_descriptions.items() %}
+                            {%for key, item in data.sidebar_info.metric_descriptions.items() | sort %}
                             <li>
                                 <a href="/descriptions/metrics/{{key}}" {%if key==data.metric_active %}
                                     class="mm-active" {%endif%}>


### PR DESCRIPTION
This PR creates an alphabetical order of the metrics' descriptions in the UI's sidebar.