### PR TITLE
REC-95 Retrieve service name from EOSC-Marketplace

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -528,7 +528,7 @@ def top5_services_recommended(object, k=5, base='https://marketplace.eosc-portal
         #   (v) percentage of the (iv) to the total number of recommendations 
         #       expressed in %, with or without anonymous, based on the function's flag
     Service's info is being retrieved from the servives.csv file 
-    (i.e. each line forms: service_id, rating, service_name, page_id)
+    (i.e. each line forms: service_id, service_name, page_id)
     """
     # keep recommendations with or without anonymous suggestions
     # based on anonymous flag (default=False, i.e. ignore anonymous)
@@ -593,7 +593,7 @@ def top5_services_ordered(object, k=5, base='https://marketplace.eosc-portal.eu'
         #   (v) percentage of the (iv) to the total number of orders 
         #       expressed in %, with or without anonymous, based on the function's flag
     Service's info is being retrieved from the services.csv file 
-    (i.e. each line forms: service_id, rating, service_name, page_id)
+    (i.e. each line forms: service_id, service_name, page_id)
     """
     # keep user actions with or without anonymous suggestions
     # based on anonymous flag (default=False, i.e. ignore anonymous)

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -93,7 +93,7 @@ else:
 run.users=pd.read_csv(os.path.join(args.input,'users.csv'),names=["User","Services"],converters={'Services': lambda x: map(int,x.split())})
     
 # populate services
-run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Rating", "Name", "Page"])
+run.services=pd.read_csv(os.path.join(args.input,'services.csv'),names=["Service", "Name", "Page"])
 
 # remove user actions when user or service does not exist in users' or services' catalogs
 # adding -1 in all catalogs indicating the anonynoums users or not-known services


### PR DESCRIPTION
This PR:

- [x] decouples MongoDB when the `page_map` is set as the source option for the services' input in the Preprocessor
- [x] for this reason, it removes services' `Rating` since none of the statistics or metrics are, currently, using it
- [x] The `name` of the service is being retrieved from the EOSC-Marketplace portal (when `page_map` is set), whereas is being retrieved from the MongoDB when `source` is set.

More info in REC-95.
