### PR TITLE
REC-124 Removal of the unneeded CSV and JSON file export from both Preprocessor and RS Metrics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,6 @@ Datastore:
         port: 27017
         db: rsmetrics
 
-    export_CSV: false
-
 Service:
     # Use the EOSC-Marketplace webpage
     # to retrieve resources and 

--- a/metrics.py
+++ b/metrics.py
@@ -31,6 +31,21 @@ def statistic(txt):
 
 # Metrics
 
+@statistic('The type of the resource')
+def type(object):
+    """
+    The type of the resource, e.g. service
+    """
+    # currently
+    return "service"
+
+@statistic('The provider of the resource')
+def provider(object):
+    """
+    The provider of the resource, e.g. cyfronet
+    """
+    # currently
+    return "cyfronet"
 
 @statistic('The initial date where metrics are calculated on')
 def start(object):

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -216,11 +216,6 @@ for ua in recdb["user_action"].find(query).sort("user"):
                 })
 
 #luas=natsorted(luas,alg=ns.ns.SIGNED)
-if config['Datastore']['export_CSV']:
-    with open(os.path.join(args.output,'user_actions.csv'), 'w') as o:
-        o.writelines(luas)
-
-
 
 recs=[]
 for rec in recdb["recommendation"].find(query).sort("user"):
@@ -239,9 +234,6 @@ for rec in recdb["recommendation"].find(query).sort("user"):
                 })
 
 #recs=natsorted(recs,alg=ns.ns.SIGNED)
-if config['Datastore']['export_CSV']:
-    with open(os.path.join(args.output,'recommendations.csv'), 'w') as o:
-        o.writelines(recs)
 
 # produce users csv with each user id along with the user's accessed services
 # query users from database for fields _id and accessed_services then create a list of rows
@@ -254,14 +246,6 @@ users = list(map(lambda x: {'id':int(str(x['_id'])),
                             'provider': 'cyfronet', # currently, static
                             'ingestion': 'batch', # currently, static 
                            }, users))
-
-# export user catalog
-if config['Datastore']['export_CSV']:
-    # save the users list of rows to a csv file
-    with open(os.path.join(args.output,'users.csv'), 'w') as f:
-        writer = csv.writer(f)
-        writer.writerows(users)
-
 
 if config['Service']['from']=='page_map':
 
@@ -304,12 +288,6 @@ else: # 'source'
 
         except:
             continue
-
-# export service catalog
-if config['Datastore']['export_CSV']:
-    with open(os.path.join(args.output,'services.csv'), 'w') as o:
-        o.writelines(resources)
-
 
 # store data to Mongo DB
 
@@ -363,7 +341,3 @@ if config['Metrics']:
 
     print(jsonstr)
 
-    if config['Datastore']['export_CSV']:
-        # Using a JSON string
-        with open(os.path.join(args.output,'pre_metrics.json'), 'w') as outfile:
-            outfile.write(jsonstr)

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -202,10 +202,10 @@ for ua in recdb["user_action"].find(query).sort("user"):
 
     reward=reward_mapping[symbolic_reward]
 
-    luas.append({'user_id':user,
-                 'source_resource_id':source_service_id, 
-                 'target_resource_id':target_service_id, 
-                 'reward':reward, 
+    luas.append({'user_id':int(user),
+                 'source_resource_id':int(source_service_id), 
+                 'target_resource_id':int(target_service_id), 
+                 'reward':float(reward), 
                  'panel':ua['source']['root']['type'], 
                  'timestamp':ua['timestamp'], 
                  'source_path':ua['source']['page_id'], 
@@ -230,7 +230,7 @@ for rec in recdb["recommendation"].find(query).sort("user"):
     except:
         user=-1
 
-    recs.append({'user_id':user,
+    recs.append({'user_id':int(user),
                  'resource_ids': rec['services'],
                  'timestamp':rec['timestamp'], 
                  'type': 'service', # currently, static
@@ -247,7 +247,7 @@ if config['Datastore']['export_CSV']:
 # query users from database for fields _id and accessed_services then create a list of rows
 # each rows contains two elements, first: user_id in string format and second: a space separated sorted list of accessed services 
 users = recdb['user'].find({},{'accessed_services':1})
-users = list(map(lambda x: {'id':str(x['_id']),
+users = list(map(lambda x: {'id':int(str(x['_id'])),
                             'accessed_resources': sorted(set(x['accessed_services'])),
                             'created_on': None,
                             'deleted_on': None,
@@ -270,7 +270,7 @@ if config['Service']['from']=='page_map':
     for s in _ss:
         try:
             #ss.append(s.strip()+',"'+rdmap[s.strip()][1]+'",'+rdmap[s.strip()][0]+'\n')
-            resources.append({'id':s.strip(),
+            resources.append({'id':int(s.strip()),
                        'name':rdmap[s.strip()][1],
                        'path':rdmap[s.strip()][0],
                        'created_on': None,
@@ -292,7 +292,7 @@ else: # 'source'
     for s in _ss:
         try:
             #ss.append(s.strip()+','+rdmap[s.split(',')[0]]+'\n')
-            resources.append({'id':s.split(',')[0],
+            resources.append({'id':int(s.split(',')[0]),
                        'name':rdmap[s.split(',')[0]][1],
                        'path':rdmap[s.split(',')[0]][0],
                        'created_on': None,

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -152,11 +152,16 @@ for func_name in func_names:
 output['metrics'] = metrics
 output['statistics'] = statistics
 
-
+# this line is necessary in order to store the output to MongoDB
 jsonstr = json.dumps(output,indent=4)
-#jsonstr = json.dumps(m.__dict__)
+
+rsmetrics_db.drop_collection("metrics")
+rsmetrics_db["metrics"].insert_one(output)
+
 print(jsonstr)
 
 # Using a JSON string
-with open(os.path.join(args.input,'metrics.json'), 'w') as outfile:
-    outfile.write(jsonstr)
+# export service catalog
+if config['Datastore']['export_CSV']:
+    with open(os.path.join(args.input,'metrics.json'), 'w') as outfile:
+        outfile.write(jsonstr)

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -42,7 +42,6 @@ required = parser.add_argument_group('required arguments')
 optional = parser.add_argument_group('optional arguments')
 
 optional.add_argument('-c', '--config', metavar=('FILEPATH'), help='override default configuration file (./config.yaml)', nargs='?', default='./config.yaml', type=str)
-optional.add_argument('-i', '--input', metavar=('FILEPATH'), help='override default output dir (./data)', nargs='?', default='./data', type=str)
 
 optional.add_argument('-s', '--starttime', metavar=('DATETIME'), help='calculate metrics starting from given datetime in ISO format (UTC) e.g. YYYY-MM-DD', nargs='?', default=None)
 optional.add_argument('-e', '--endtime', metavar=('DATETIME'), help='calculate metrics ending to given datetime in ISO format (UTC) e.g. YYYY-MM-DD', nargs='?', default=None)
@@ -160,8 +159,3 @@ rsmetrics_db["metrics"].insert_one(output)
 
 print(jsonstr)
 
-# Using a JSON string
-# export service catalog
-if config['Datastore']['export_CSV']:
-    with open(os.path.join(args.input,'metrics.json'), 'w') as outfile:
-        outfile.write(jsonstr)


### PR DESCRIPTION
This PR resolves REC-124 and REC-125. That is:

- Removal of the unneeded CSV and JSON file exporting functionality from Preprocessor
- Removal of the unneeded JSON file exporting functionality from RS Metrics
- Removal of the respective option from the configuration file format
- Removal of the `input` flag from RS Metrics since no files or directory is needed

The `output` flag that specifies the output directory at the Preprocessor is preserved since page_map might be set as a source option, thus a directory would be needed to be assigned.
