### PR TITLE
REC-129 Update api to support reports

### DIFF
--- a/webservice/app.py
+++ b/webservice/app.py
@@ -1,90 +1,142 @@
-from flask import Flask, render_template, jsonify, abort
+from flask import Flask, render_template, jsonify, abort, request, redirect
 from flask_pymongo import PyMongo
-import json, os, re 
+import json
+import os
+import re
 from dotenv import load_dotenv
 import yaml
-
 
 
 app = Flask('RS_EVALUATION')
 dotenv_path = os.path.join(app.instance_path, '.env')
 load_dotenv(dotenv_path)
 
-app.config['RS_EVALUATION_METRIC_DESC_DIR'] = os.environ.get('RS_EVALUATION_METRIC_DESC_DIR')
+app.config['RS_EVALUATION_METRIC_DESC_DIR'] = os.environ.get(
+    'RS_EVALUATION_METRIC_DESC_DIR')
 app.config["MONGO_URI"] = os.environ.get('RS_EVALUATION_MONGO_URI')
 mongo = PyMongo(app)
 
+
 def load_sidebar_info():
-  '''Reads the available metric description yaml files in metric description folder path
-  and creates dynamically a list of full names -> short names of metric descriptions
-  in order to create automatically the appropriate links in sidebar
-  '''
-  folder = app.config['RS_EVALUATION_METRIC_DESC_DIR']
-  desc = {}
-  app.logger.info('Opening metric description folder %s to gather sidebar info...',folder)
-  try:
-    for filename in os.listdir(folder):
-      if filename.endswith(".yml"):
-        with open(os.path.join(folder,filename), 'r') as f:
-          app.logger.info('Opening metric description file %s',filename)
-          result = yaml.safe_load(f)
-          # Remove .yml suffix from filename
-          name=re.sub('\.yml$', '', filename)
-          desc[name]= { 'fullname': result['name'], 'style': result['style']}
-  except:
-    app.logger.error('Could not load sidebar info from metric description folder:%s',app.config['RS_EVALUATION_METRIC_DESC'])
-  return {'metric_descriptions':desc}
+    '''Reads the available metric description yaml files in metric description folder path
+    and creates dynamically a list of full names -> short names of metric descriptions
+    in order to create automatically the appropriate links in sidebar
+    '''
+    folder = app.config['RS_EVALUATION_METRIC_DESC_DIR']
+    desc = {}
+    app.logger.info(
+        'Opening metric description folder %s to gather sidebar info...', folder)
+    try:
+        for filename in os.listdir(folder):
+            if filename.endswith(".yml"):
+                with open(os.path.join(folder, filename), 'r') as f:
+                    app.logger.info(
+                        'Opening metric description file %s', filename)
+                    result = yaml.safe_load(f)
+                    # Remove .yml suffix from filename
+                    name = re.sub('\.yml$', '', filename)
+                    desc[name] = {'fullname': result['name'],
+                                  'style': result['style']}
+    except:
+        app.logger.error('Could not load sidebar info from metric description folder:%s',
+                         app.config['RS_EVALUATION_METRIC_DESC'])
+    return {'metric_descriptions': desc}
+
 
 app.sidebar_info = load_sidebar_info()
 
-def db_get_metrics():
+
+def respond_report_404(provider_name):
+    return jsonify("Results for report: {} not found!".format(provider_name)), 404
+
+
+def respond_metric_404(metric_name):
+    return jsonify({'code': 404, 'error': 'metric with name: {} does not exist!'.format(metric_name)}), 404
+
+
+def respond_stat_404(stat_name):
+    return jsonify({'code': 404, 'error': 'statistic with name: {} does not exist!'.format(stat_name)}), 404
+
+
+def db_get_provider_names():
+    '''Get a list of the names of the providers handled in the system'''
+    result = mongo.db.metrics.find({}, {"_id": 0, "provider": 1})
+    providers = []
+    for item in result:
+        providers.append(item["provider"])
+    return providers
+
+
+def db_get_metrics(provider_name):
     '''Get evaluated metric results from mongodb'''
-    return mongo.db.metrics.find_one({},{"_id":0})
+    return mongo.db.metrics.find_one({'provider': provider_name}, {"_id": 0})
+
 
 @app.route("/", strict_slashes=False)
 def html_index():
-  '''Serve the main page that constructs the report view'''
-  return render_template('./index.html')   
+    '''Serve the main page that constructs the report view'''
+    return render_template('./index.html')
+
 
 @app.route("/ui", strict_slashes=False)
-def html_metrics():
+def html_default_report():
+    '''Select the first available provider and serve it's report as default'''
+    default = db_get_provider_names()[0]
+    return redirect("/ui/reports/{}".format(default), code=302)
+
+@app.route("/ui/reports/<string:provider_name>", strict_slashes=False)
+def html_metrics(provider_name):
     '''Serve the main metrics dashboard'''
+    reports = db_get_provider_names()
+    if not provider_name in reports:
+        abort(404)
+    
     result = {}
-    stats_needed = ['users', 'recommendations', 'services', 'user_actions', 
-    'user_actions_registered', 'user_actions_registered_perc', 
-    'user_actions_anonymous', 'user_actions_anonymous_perc',
-    'user_actions_order', 'user_actions_order_registered', 'user_actions_order_registered_perc',
-    'user_actions_order_anonymous','user_actions_order_anonymous_perc','start','end']
+    stats_needed = ['users', 'recommendations', 'services', 'user_actions',
+                    'user_actions_registered', 'user_actions_registered_perc',
+                    'user_actions_anonymous', 'user_actions_anonymous_perc',
+                    'user_actions_order', 'user_actions_order_registered', 'user_actions_order_registered_perc',
+                    'user_actions_order_anonymous', 'user_actions_order_anonymous_perc', 'start', 'end']
     for stat_name in stats_needed:
-      result[stat_name] = get_statistic(stat_name).get_json()
-    
-    metrics_needed = ['user_coverage', 'catalog_coverage', 'diversity', 'diversity_gini', 'novelty']
-    
-    for metric_name in metrics_needed:  
-      result[metric_name] = get_metric(metric_name).get_json()
+        result[stat_name] = get_statistic(provider_name, stat_name).get_json()
 
-    result['timestamp'] = get_api_index().get_json()['timestamp']
+    metrics_needed = ['user_coverage', 'catalog_coverage',
+                      'diversity', 'diversity_gini', 'novelty']
 
+    for metric_name in metrics_needed:
+        result[metric_name] = get_metric(provider_name, metric_name).get_json()
+
+    result['timestamp'] = get_api_index(provider_name).get_json()['timestamp']
+    result['report'] = provider_name
+    result['reports'] = reports
     result['sidebar_info'] = app.sidebar_info
     result['metric_active'] = None
-    return render_template('./rsmetrics.html',data=result)   
+    return render_template('./rsmetrics.html', data=result)
 
-@app.route("/ui/kpis", strict_slashes=False)
-def html_kpis():
-    '''Serve html page about kpis'''
+
+@app.route("/ui/reports/<string:provider_name>/kpis", strict_slashes=False)
+def html_kpis(provider_name):
+    '''Serve html page about kpis per provider'''
     # call directly the get_metrics flask method implemented in our api to get json about all metrics
+    reports = db_get_provider_names()
+    if not provider_name in reports:
+        abort(404)
+
     result = {}
 
-    stats_needed = ['start','end']
+    stats_needed = ['start', 'end']
     for stat_name in stats_needed:
-      result[stat_name] = get_statistic(stat_name).get_json()
+        result[stat_name] = get_statistic(provider_name, stat_name).get_json()
 
-    metrics_needed = ['hit_rate', 'click_through_rate', 'top5_services_ordered', 'top5_services_recommended']   
+    metrics_needed = ['hit_rate', 'click_through_rate',
+                      'top5_services_ordered', 'top5_services_recommended']
     for metric_name in metrics_needed:
-      result[metric_name] = get_metric(metric_name).get_json()
+        result[metric_name] = get_metric(provider_name, metric_name).get_json()
 
-    result['timestamp'] = get_api_index().get_json()['timestamp']
+    result['timestamp'] = get_api_index(provider_name).get_json()['timestamp']
     result['sidebar_info'] = app.sidebar_info
+    result['report'] = provider_name
+    result['reports'] = reports
     result['metric_active'] = None
 
     return render_template('./kpis.html', data=result)
@@ -93,61 +145,76 @@ def html_kpis():
 @app.route("/ui/descriptions/metrics/<string:metric_name>", strict_slashes=False)
 def html_metric_description(metric_name):
     '''Serve html page about description of a specific metric'''
+    reports = db_get_provider_names()
     result = {}
 
-    # compose path to open correct yaml file 
+    # compose path to open correct yaml file
     dir = app.config['RS_EVALUATION_METRIC_DESC_DIR']
     filename = metric_name + ".yml"
     try:
-      with open(os.path.join(dir,filename), 'r') as f:
-        result = yaml.safe_load(f)
-        result['sidebar_info'] = app.sidebar_info
-        result['metric_active'] = metric_name
+        with open(os.path.join(dir, filename), 'r') as f:
+            result = yaml.safe_load(f)
+            result['sidebar_info'] = app.sidebar_info
+            result['metric_active'] = metric_name
     except:
-      abort(404)
-
+        abort(404)
+    # ref to know from which report metrics/kpis page were transitioned to here
+    result['ref']= request.args.get('ref')
+    result['reports'] = reports
     return render_template('./metric_desc.html', data=result)
 
 
-
-
-@app.route("/api")
-def get_api_index():
+@app.route("/api/reports/<string:provider_name>")
+def get_api_index(provider_name):
     '''Serve metrics and statistics as default api response'''
-    result = db_get_metrics()
+    result = db_get_metrics(provider_name)
     return jsonify(result)
 
 
-@app.route("/api/metrics")
-def get_metrics():
+@app.route("/api/reports")
+def get_reports():
+    '''Get provider names'''
+    return jsonify(db_get_provider_names())
+
+
+@app.route("/api/reports/<string:provider_name>/metrics")
+def get_metrics(provider_name):
     '''Serve the metrics data in json format'''
-    result = db_get_metrics()
+    result = db_get_metrics(provider_name)
+    if not result:
+        return respond_report_404(provider_name)
     return jsonify(result['metrics'])
 
-@app.route("/api/metrics/<string:metric_name>")
-def get_metric(metric_name):
-    '''Serve specific metric data in json format'''
-    result = db_get_metrics()
-    
-    for metric in result['metrics']:
-      if metric['name'] == metric_name:
-        return jsonify(metric)
-    
-    return jsonify({'code':404,'error':'metric with name: {} does not exist!'.format(metric_name)}),404
 
-@app.route("/api/statistics")
-def get_statistics():
+@app.route("/api/reports/<string:provider_name>/metrics/<string:metric_name>")
+def get_metric(provider_name, metric_name):
+    '''Serve specific metric data in json format'''
+    result = db_get_metrics(provider_name)
+    if not result:
+        return respond_report_404(provider_name)
+    for metric in result['metrics']:
+        if metric['name'] == metric_name:
+            return jsonify(metric)
+    return respond_metric_404(metric_name)
+
+
+@app.route("/api/reports/<string:provider_name>/statistics")
+def get_statistics(provider_name):
     '''Serve the statistics data in json format'''
-    result = db_get_metrics()
+    result = db_get_metrics(provider_name)
+    if not result:
+        return respond_report_404(provider_name)
     return jsonify(result['statistics'])
 
-@app.route("/api/statistics/<string:stat_name>")
-def get_statistic(stat_name):
+
+@app.route("/api/reports/<string:provider_name>/statistics/<string:stat_name>")
+def get_statistic(provider_name, stat_name):
     '''Serve specific statistic data in json format'''
-    result = db_get_metrics()
-    
+    result = db_get_metrics(provider_name)
+    if not result:
+        return respond_report_404(provider_name)
     for stat in result['statistics']:
-      if stat['name'] == stat_name:
-        return jsonify(stat)
-    
-    return jsonify({'code':404,'error':'metric with name: {} does not exist!'.format(stat_name)}),404
+        if stat['name'] == stat_name:
+            return jsonify(stat)
+    return respond_stat_404(stat_name)
+

--- a/webservice/templates/kpis.html
+++ b/webservice/templates/kpis.html
@@ -63,6 +63,12 @@
             </div>
             <div class="app-header__content">
                 <div class="app-header-left">
+                        <div class="widget-content"><span class="text-light h5">Report:</span></div> 
+                        <div class="widget-content"><select class="form-select" onchange="if (this.value) window.location.href=this.value">
+                            {%for item in data.reports | sort %}
+                            <option value="/ui/reports/{{item}}/kpis" {%if item==data.report %} selected {%endif%}>{{item}}</option>
+                            {%endfor%}
+                        </select></div>
                 </div>
             </div>
         </div>
@@ -143,13 +149,13 @@
                         <ul class="vertical-nav-menu">
                             <li class="app-sidebar__heading">Metrics Dashboard</li>
                             <li>
-                                <a href="/ui">
+                                <a href="/ui/reports/{{data.report}}">
                                     <i class="metismenu-icon pe-7s-rocket"></i>
                                     RS Metrics
                                 </a>
                             </li>
                             <li>
-                                <a href="/ui/kpis" class="mm-active">
+                                <a href="/ui/reports/{{data.report}}/kpis" class="mm-active">
                                     <i class="metismenu-icon pe-7s-key"></i>
                                     KPIs
                                 </a>
@@ -157,7 +163,7 @@
                             <li class="app-sidebar__heading">Metrics Documentation</li>
                             {%for key, item in data.sidebar_info.metric_descriptions.items() | sort %}
                             <li>
-                                <a href="/ui/descriptions/metrics/{{key}}" {%if key==data.metric_active %}
+                                <a href="/ui/descriptions/metrics/{{key}}?ref={{data.report}}" {%if key==data.metric_active %}
                                     class="mm-active" {%endif%}>
                                     <i class="metismenu-icon {{item.style.icon}}"></i>
                                     {{item.fullname}}
@@ -211,7 +217,7 @@
 
                                         <div class="widget-heading">
                                             <h4>Click-Through Rate
-                                                <a href="/ui/descriptions/metrics/click-through-rate">
+                                                <a href="/ui/descriptions/metrics/click-through-rate?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0"><i
                                                             class="fa fa-address-card icon-gradient bg-plum-plate"></i></span>
                                                 </a>
@@ -241,7 +247,7 @@
 
                                         <div class="widget-heading">
                                             <h4>Hit Rate
-                                                <a href="/ui/descriptions/metrics/hit-rate">
+                                                <a href="/ui/descriptions/metrics/hit-rate?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0"><i
                                                             class="fa fa-address-card icon-gradient bg-plum-plate"></i></span>
                                                 </a>

--- a/webservice/templates/metric_desc.html
+++ b/webservice/templates/metric_desc.html
@@ -63,6 +63,12 @@
             </div>
             <div class="app-header__content">
                 <div class="app-header-left">
+                            <div class="widget-content"><span class="text-light h5">Report:</span></div> 
+                            <div class="widget-content"><select class="form-select" onchange="if (this.value) window.location.href=this.value">
+                                {%for item in data.reports | sort %}
+                                <option value="/ui/descriptions/metrics/{{data.metric_active}}?ref={{item}}" {%if item==data.ref %} selected {%endif%}>{{item}}</option>
+                                {%endfor%}
+                            </select></div>
                 </div>
             </div>
         </div>
@@ -156,13 +162,13 @@
                         <ul class="vertical-nav-menu">
                             <li class="app-sidebar__heading">Metrics Dashboard</li>
                             <li>
-                                <a href="/ui" >
+                                <a href="/ui/reports/{{data.ref}}" >
                                     <i class="metismenu-icon pe-7s-rocket"></i>
                                     RS Metrics
                                 </a>
                             </li>
                             <li>
-                                <a href="/ui/kpis">
+                                <a href="/ui/reports/{{data.ref}}/kpis">
                                     <i class="metismenu-icon pe-7s-key"></i>
                                     KPIs
                                 </a>
@@ -170,7 +176,7 @@
                             <li class="app-sidebar__heading">Metrics Documentation</li>
                             {%for key, item in data.sidebar_info.metric_descriptions.items() | sort %}
                             <li>
-                                <a href="/ui/descriptions/metrics/{{key}}" {%if key == data.metric_active %} class="mm-active" {%endif%} >
+                                <a href="/ui/descriptions/metrics/{{key}}?ref={{data.ref}}" {%if key == data.metric_active %} class="mm-active" {%endif%} >
                                     <i class="metismenu-icon {{item.style.icon}}"></i>
                                     {{item.fullname}}
                                 </a>

--- a/webservice/templates/rsmetrics.html
+++ b/webservice/templates/rsmetrics.html
@@ -63,6 +63,12 @@
             </div>
             <div class="app-header__content">
                 <div class="app-header-left">
+                    <div class="widget-content"><span class="text-light h5">Report:</span></div> 
+                    <div class="widget-content"><select class="form-select" onchange="if (this.value) window.location.href=this.value">
+                        {%for item in data.reports | sort %}
+                        <option value="/ui/reports/{{item}}" {%if item==data.report %} selected {%endif%}>{{item}}</option>
+                        {%endfor%}
+                    </select></div>
                 </div>
             </div>
         </div>
@@ -110,6 +116,7 @@
                     <div class="logo-src"></div>
                     <div class="header__pane ms-auto">
                         <div>
+                            
                             <button type="button" class="hamburger close-sidebar-btn hamburger--elastic"
                                 data-class="closed-sidebar">
                                 <span class="hamburger-box">
@@ -141,15 +148,17 @@
                 <div class="scrollbar-sidebar">
                     <div class="app-sidebar__inner">
                         <ul class="vertical-nav-menu">
+                            
                             <li class="app-sidebar__heading">Metrics Dashboard</li>
+                            
                             <li>
-                                <a href="/ui" class="mm-active">
+                                <a href="/ui/reports/{{data.report}}" class="mm-active">
                                     <i class="metismenu-icon pe-7s-rocket"></i>
                                     RS Metrics
                                 </a>
                             </li>
                             <li>
-                                <a href="/ui/kpis">
+                                <a href="/ui/reports/{{data.report}}/kpis">
                                     <i class="metismenu-icon pe-7s-key"></i>
                                     KPIs
                                 </a>
@@ -157,7 +166,7 @@
                             <li class="app-sidebar__heading">Metrics Documentation</li>
                             {%for key, item in data.sidebar_info.metric_descriptions.items() | sort %}
                             <li>
-                                <a href="/ui/descriptions/metrics/{{key}}" {%if key==data.metric_active %}
+                                <a href="/ui/descriptions/metrics/{{key}}?ref={{data.report}}" {%if key==data.metric_active %}
                                     class="mm-active" {%endif%}>
                                     <i class="metismenu-icon {{item.style.icon}}"></i>
                                     {{item.fullname}}
@@ -401,7 +410,7 @@
                                         <div class="widget-content-left">
                                             <div class="widget-heading">
                                                 <h4>User Coverage
-                                                    <a href="/ui/descriptions/metrics/user-coverage">
+                                                    <a href="/ui/descriptions/metrics/user-coverage?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0">
                                                         <i class="fa fa-address-card icon-gradient bg-plum-plate"></i>
                                                     </span>
@@ -441,7 +450,7 @@
                                         <div class="widget-content-left">
                                             <div class="widget-heading">
                                                 <h4>Catalog Coverage
-                                                    <a href="/ui/descriptions/metrics/catalog-coverage">
+                                                    <a href="/ui/descriptions/metrics/catalog-coverage?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0">
                                                         <i class="fa fa-address-card icon-gradient bg-plum-plate"></i>
                                                     </span>
@@ -485,7 +494,7 @@
                                         <div class="widget-content-left">
                                             <div class="widget-heading">
                                                 <h4>Diversity (Gini Index)
-                                                    <a href="/ui/descriptions/metrics/diversity-gini">
+                                                    <a href="/ui/descriptions/metrics/diversity-gini?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0">
                                                         <i class="fa fa-address-card icon-gradient bg-plum-plate"></i>
                                                     </span>
@@ -541,7 +550,7 @@
                                         <div class="widget-content-left">
                                             <div class="widget-heading">
                                                 <h4>Diversity (Sh. Entropy)
-                                                    <a href="/ui/descriptions/metrics/diversity">
+                                                    <a href="/ui/descriptions/metrics/diversity?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0">
                                                         <i class="fa fa-address-card icon-gradient bg-plum-plate"></i>
                                                     </span>
@@ -582,7 +591,7 @@
                                         <div class="widget-content-left">
                                             <div class="widget-heading">
                                                 <h4>Novelty
-                                                    <a href="/ui/descriptions/metrics/novelty">
+                                                    <a href="/ui/descriptions/metrics/novelty?ref={{data.report}}">
                                                     <span class="font-icon-wrapper font-icon-m" style="border:0">
                                                         <i class="fa fa-address-card icon-gradient bg-plum-plate"></i>
                                                     </span>


### PR DESCRIPTION
REC-130 Update UI to support reports

## Goal 🎯 
Preprocessor & evaluation components now support producing results per provider (as different reports). API and UI must be extended to support results from different providers in the form of reports

## Implementation ⚒️ 

### Changes in the API 
Change endpoint paths to incorporate the notion of `report`. Each report is named after the provider. The API paths change in the following order:

👉 **get metrics** 
from: `/api/metrics`
to: `/api/reports/{provider-name}/metrics`

👉 **get statistics**
from: `/api/statistics`
to: `/api/reports/{provider-name}/statistics`

👉 **get all (both metrics & statistics)**
from: `/api`
to: `/api/reports/{provider-name}`

similar changes in subpaths (for example for selecting _specific_ **metric** or **statistic**)

There is also a new api method `get_available_reports` which returns a simple list of provider names for which results have been produced and are available for display
👉 **request:**
`HTTP GET /api/reports`
👉 **response:**
```json
["name-a", "name-b", "name-c"]
```
This comes in handy in the ui to render controls that allow the user to select one from the available reports.

### Changes in the UI
Ui paths that serve the html views for metrics, kpis and metric descriptions have been changed as well.

👉 **Show metrics dashboard** 
from: `/ui`
to: `/ui/reports/{provider-name}`

👉 **Show kpis dashboard**
from: `/ui/kpis`
to: `/ui/reports/{provider-name}/kpis`

Metrics description path remains the same (because its scope is outside of reports) but actually tracks a `?ref=` url string variable that points to the current report that the user made a transition from landing to the description page. This allows to correctly adjust the links in the sidebar pointing to the correct report for the `KPIs` and `METRICS` views

Also added to the top header of the dashboard a section that the user can select one of the available reports from the dropdown menu essentially activating it. This works on each view

Another change is the default entry path of the ui application `/ui` now actually redirects to the first available report and shows it's main metrics dashboard 
