### PR TITLE
REC-134 Remove intermediate files and add caching option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A framework for counting the recommender metrics
 ```bash
 ./preprocessor_common.py # this will ingest users and resources [from scratch] by retrieving the data from 'cyfronet' provider (which is specified in the config file
 ./preprocessor_common.py -p cyfronet # equivalent to first one
+./preprocessor_common.py -p cyfronet --use-cache # equivalent to first one but use the cache file to read resources instead of downloading them via the EOSC Marketplace
 ./preprocessor_common.py -p athena # currently is not working since users collection only exist in 'cyfronet'
 ```
 7. Run from terminal: `./preprocessor.py -p <provider>` in order to gather `user_actions` and `recommendations` from the particular provider and store them in the `Datastore`:

--- a/config.yaml
+++ b/config.yaml
@@ -13,11 +13,8 @@ datastore: "mongodb://localhost:27017/rsmetrics"
 
 service:
     # Use the EOSC-Marketplace webpage
-    # to retrieve resources and 
-    # associate the page_id and the service_id
-    portal:
-        download: true
-        path: ./page_map
+    # to retrieve resources and associate the page_id and the service_id
+    store: './page_map' # or null
 
     # if true it keeps only published, otherwise all
     # this has an effect in exporting when from is set to 'source' 


### PR DESCRIPTION
In this PR, the affected software is the `preprocessor_common.py`:
- [x] The creation of the intermediate file `page_map` has been disabled.
- [x] No `output` directory is created and the respective `output` option is removed from the possible program's arguments.
- [x] A reformation of the configuration, where now it has a `store` option (that points to cache path). If `null`, no caching store of the resources happens, otherwise they are stored in the respective path.
- [x] A `--use-cache` option is introduced in order to use the `store` file (cache) to retrieve the resources, otherwise it downloads them from the EOSC Marketplace
- [x] README file is updated accordingly