### PR TITLE
Manual Bump certifi from 2021.10.8 to 2022.12.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,53 +2,53 @@ name: rsmetrics
 channels:
   - defaults
 dependencies:
-  - _libgcc_mutex=0.1=main
-  - _openmp_mutex=4.5=1_gnu
-  - ca-certificates=2022.3.18=h06a4308_0
-  - certifi=2021.10.8=py39h06a4308_2
-  - ld_impl_linux-64=2.35.1=h7274673_9
-  - libffi=3.3=he6710b0_2
-  - libgcc-ng=9.3.0=h5101ec6_17
-  - libgomp=9.3.0=h5101ec6_17
-  - libstdcxx-ng=9.3.0=hd4cf53a_17
-  - ncurses=6.3=h7f8727e_2
-  - openssl=1.1.1n=h7f8727e_0
-  - pip=21.2.4=py39h06a4308_0
-  - python=3.9.11=h12debd9_2
-  - readline=8.1.2=h7f8727e_1
-  - setuptools=58.0.4=py39h06a4308_0
-  - sqlite=3.38.0=hc218d9a_0
-  - tk=8.6.11=h1ccaba5_0
-  - tzdata=2021e=hda174b7_0
-  - wheel=0.37.1=pyhd3eb1b0_0
-  - xz=5.2.5=h7b6447c_0
-  - zlib=1.2.11=h7f8727e_4
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - ca-certificates=2022.3.18
+  - ld_impl_linux-64=2.35.1
+  - libffi=3.3
+  - libgcc-ng=9.3.0
+  - libgomp=9.3.0
+  - libstdcxx-ng=9.3.0
+  - ncurses=6.3
+  - openssl=1.1.1n
+  - pip=21.2.4
+  - python=3.9.11
+  - readline=8.1.2
+  - setuptools=58.0.4
+  - sqlite=3.38.0
+  - tk=8.6.11
+  - tzdata=2021e
+  - wheel=0.37.1
+  - xz=5.2.5
+  - zlib=1.2.11
   - pip:
     - beautifulsoup4==4.10.0
-    - certifi==2021.10.8
+    - certifi==2022.12.7
     - charset-normalizer==2.0.12
     - click==8.1.3
-    - Flask==2.1.2
+    - flask==2.1.2
+    - flask-pymongo==2.3.0
     - idna==3.3
     - importlib-metadata==4.11.4
     - itsdangerous==2.1.2
-    - Jinja2==3.1.2
+    - jinja2==3.1.2
     - joblib==1.2.0
-    - MarkupSafe==2.1.1
+    - markupsafe==2.1.1
     - natsort==8.1.0
     - numpy==1.22.3
     - pandas==1.4.2
+    - pyarrow==10.0.1
     - pymongo==4.1.0
+    - pymongoarrow==0.6.2
     - python-dateutil==2.8.2
     - python-dotenv==0.20.0
     - pytz==2022.1
-    - PyYAML==6.0
+    - pyyaml==6.0
     - requests==2.27.1
     - scipy==1.8.0
     - six==1.16.0
     - soupsieve==2.3.2
     - urllib3==1.26.9
-    - Werkzeug==2.1.2
+    - werkzeug==2.1.2
     - zipp==3.8.0
-    - flask-pymongo==2.3.0
-    - pymongoarrow==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.10.0
-certifi==2021.10.8
+certifi==2022.12.7
 charset-normalizer==2.0.12
 click==8.1.3
 Flask==2.1.2


### PR DESCRIPTION
This PR adds a newer version of certifi suggested by the dependabot, after checking that it does not break anything.