### PR TITLE
REC-199 Update healthcheck with db and streaming statuses

### DIFF
--- a/webservice/.env
+++ b/webservice/.env
@@ -1,2 +1,5 @@
-RS_EVALUATION_MONGO_URI=mongodb://localhost:27017/rsmetrics
-RS_EVALUATION_METRIC_DESC_DIR=../metric_descriptions
+RSEVAL_MONGO_URI=mongodb://localhost:27017/rsmetrics
+RSEVAL_METRIC_DESC_DIR=../metric_descriptions
+RSEVAL_SUPERVISOR_RPC_SERVER=http://localhost:9001/RPC2
+RSEVAL_STREAM_USER_ACTIONS_JOBNAME=stream-user-actions
+RSEVAL_STREAM_MP_DB_EVENTS_JOBNAME=stream-mp-db-events


### PR DESCRIPTION
⚠️ please merge first: https://github.com/ARGOeu/argo-ansible/pull/542 
# Goal
Update current health check endpoint `/diag` to display status information about the datastore component, the api and the streaming connectors. General status of the service is affected by api and datastore. Streaming status can be down or paused momentarily without the service being affected. __todo: We can extend the checks to affect general status if streaming is down for a long period of time__

Example response (with streaming temporarily down):
```json

  "RS_metrics": {
    "status": "UP",
    "RS_metrics_api": {
      "status": "UP"
    },
    "RS_metrics_datastore": {
      "status": "UP"
    },
    "RS_streaming": {
      "status": "DOWN",
      "RS_streaming_user_actions": {
        "status": "DOWN"
      },
      "RS_streaming_mp_events": "DOWN"
    }
  }
  ```
