### PR TITLE
REC-175 Process service_events and update service information accordingly

### DIFF
--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -231,14 +231,20 @@ run.users.columns = [
     "Provider",
     "Ingestion",
 ]
+
 logging.info("Reading services...")
 run.services = pd.DataFrame(
-    list(
-        rsmetrics_db["resources"].find(
-            {"provider": {"$in": [args.provider]}}, {"_id": 0}
-        )
-    )
+    list(rsmetrics_db["resources"].find({
+        "$and": [
+            {"provider": {"$in": [args.provider]}},
+            {"$or": [{"created_on": {"$lte": args.endtime}},
+                     {"created_on": None}]},
+            {"$or": [{"deleted_on": {"$gte": args.starttime}},
+                     {"deleted_on": None}]},
+        ]},
+        {"_id": 0}))
 )
+
 run.services.columns = [
     "Service",
     "Name",


### PR DESCRIPTION
This PR handles service events. Particularly:

- It modifies the `resources` collection so that:
    - if an `update` or `delete` keyword is found in `cud`, then it updates the user entry, concerning the fields: name, deleted_on, type, provider, and ingestion. In the `delete` case the `deleted_on` entry is set with the timestamp of the event, otherwise, it is set to None.
    - if a `create` keyword is found in `cud`, then it creates a new user. The fields that are set are: name, created_on, deleted_on, type, provider, and ingestion. The `created_on` entry is set with the timestamp of the event.

- Additionally, the `rsmetrics.py` was modified so that it filters users based on their `created_on` or `deleted_on` values.
  - Specifically, if a resource has the `created_on` or the `deleted_on` value set to `None` is qualified for the metrics computation or
  - if the `created_on` value is less than or equal to the given end time or
  - if the `deleted_on` value is greater than or equal to the given start time