### PR TITLE
REC-204 Move user actions from preprocessor to preprocessor_common

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
     - pandas==1.4.2
     - pyarrow==10.0.1
     - pymongo==4.1.0
-    - pymongoarrow==0.6.2
+    - pymongoarrow==0.7.0
     - python-dateutil==2.8.2
     - python-dotenv==0.20.0
     - pytz==2022.1

--- a/preprocessor_common.py
+++ b/preprocessor_common.py
@@ -7,8 +7,12 @@ from datetime import datetime
 import natsort as ns
 from natsort import natsorted
 import logging
+import pandas as pd
+import os
 
 # local lib
+import reward_mapping as rm
+
 from get_service_catalog import (
     get_eosc_marketplace_url,
     get_service_catalog_items,
@@ -56,7 +60,7 @@ def remove_service_prefix(text):
 
 
 parser = argparse.ArgumentParser(
-    prog="preprocessor",
+    prog="preprocessor_common",
     description="Prepare data for the EOSC Marketplace RS metrics calculation",
     add_help=False,
 )
@@ -104,7 +108,7 @@ optional.add_argument(
 )
 optional.add_argument(
     "--use-cache",
-    help=("Use the specified file in configuration as the file to read ",
+    help=("Use the specified file in configuration as the file to read "
           "resources"),
     action="store_true",
 )
@@ -146,12 +150,21 @@ if not provider:
     print("Given provider not in configuration")
     sys.exit(0)
 
-# connect to db server
-myclient = pymongo.MongoClient(provider["db"],
-                               uuidRepresentation="pythonLegacy")
+# connect to Connector DB
+connector = pymongo.MongoClient(provider["db"],
+                                uuidRepresentation="pythonLegacy")
 
 # use db
-recdb = myclient[provider["db"].split("/")[-1]]
+recdb = connector[provider["db"].split("/")[-1]]
+
+# connect to Datastore DB
+
+# connect to db server
+datastore = pymongo.MongoClient(config["datastore"],
+                                uuidRepresentation="pythonLegacy")
+
+# use db
+rsmetrics_db = datastore[config["datastore"].split("/")[-1]]
 
 # automatically associate page ids to service ids
 # default to no caching
@@ -186,6 +199,8 @@ names = list(map(lambda x: x[1], eosc_service_results))
 
 rdmap = dict(zip(ids, zip(keys, names)))
 
+# A. Working on users
+
 # 1) produce users csv with each user id along with the user's accessed
 # services
 # 2) query users from database for fields _id and accessed_services then create
@@ -207,6 +222,18 @@ users = list(
         users,
     )
 )
+
+rsmetrics_db["users"].delete_many(
+    {
+        "provider": {"$in": ["cyfronet", "athena"]},
+        "ingestion": "batch",
+    }
+)
+rsmetrics_db["users"].insert_many(users)
+
+logging.info("Users collection stored...")
+
+# B. Working on resources
 
 if config["service"]["from"] == "page_map":
 
@@ -261,23 +288,6 @@ else:  # 'source'
             }
         )
 
-# store data to Mongo DB
-
-# connect to db server
-datastore = pymongo.MongoClient(config["datastore"],
-                                uuidRepresentation="pythonLegacy")
-
-# use db
-rsmetrics_db = datastore[config["datastore"].split("/")[-1]]
-
-rsmetrics_db["users"].delete_many(
-    {
-        "provider": {"$in": ["cyfronet", "athena"]},
-        "ingestion": "batch",
-    }
-)
-rsmetrics_db["users"].insert_many(users)
-
 rsmetrics_db["resources"].delete_many(
     {
         "provider": {"$in": ["cyfronet", "athena"]},
@@ -285,3 +295,122 @@ rsmetrics_db["resources"].delete_many(
     }
 )
 rsmetrics_db["resources"].insert_many(resources)
+
+logging.info("Resources collection stored...")
+
+# C. Working on user_actions
+
+
+class Mock:
+    pass
+
+
+class User_Action:
+    def __init__(self, source_page_id, target_page_id, order):
+        self.source = Mock()
+        self.target = Mock()
+        self.action = Mock()
+        self.source.page_id = source_page_id
+        self.target.page_id = target_page_id
+        self.action.order = order
+
+
+reward_mapping = {
+    "order": 1.0,
+    "interest": 0.7,
+    "mild_interest": 0.3,
+    "simple_transition": 0.0,
+    "unknown_transition": 0.0,
+    "exit": 0.0,
+}
+
+# reward_mapping.py is modified so that the function
+# reads the Transition rewards csv file once
+# consequently, one argument has been added to the
+# called function
+ROOT_DIR = "./"
+
+TRANSITION_REWARDS_CSV_PATH = os.path.join(
+    ROOT_DIR, "resources", "transition_rewards.csv"
+)
+transition_rewards_df = pd.read_csv(TRANSITION_REWARDS_CSV_PATH,
+                                    index_col="source")
+
+# reading resources to be used for filtering user_actions
+resources = pd.DataFrame(
+    list(rsmetrics_db["resources"]
+         .find({"provider": {"$in": [args.provider]}}))
+).iloc[:, 1:]
+
+resources.columns = [
+    "Service",
+    "Name",
+    "Page",
+    "Created_on",
+    "Deleted_on",
+    "Type",
+    "Provider",
+    "Ingestion",
+]
+resources = pd.Series(resources["Service"].values,
+                      index=resources["Page"]).to_dict()
+
+luas = []
+col = "user_actions" if provider["name"] == "athena" else "user_action"
+for ua in recdb[col].find(query).sort("user"):
+    # set -1 to anonymous users
+    user = -1
+    if "user" in ua:
+        user = ua["user"]
+
+    # process data that map from page id to service id exist
+    # for both source and target page ids
+    # if not set service id to -1
+    try:
+        _pageid = "/" + "/".join(ua["source"]["page_id"].split("/")[1:3])
+        source_service_id = resources[_pageid]
+    except (KeyError, IndexError):
+        source_service_id = -1
+
+    try:
+        _pageid = "/" + "/".join(ua["target"]["page_id"].split("/")[1:3])
+        target_service_id = resources[_pageid]
+    except KeyError:
+        target_service_id = -1
+
+    # function has been modified where one more argument is given
+    # in order to avoid time-consuming processing of reading csv file
+    # for every func call
+    symbolic_reward = rm.ua_to_reward_id(
+        transition_rewards_df,
+        User_Action(
+            ua["source"]["page_id"],
+            ua["target"]["page_id"],
+            ua["action"]["order"]
+        ),
+    )
+
+    reward = reward_mapping[symbolic_reward]
+
+    luas.append(
+        {
+            "user_id": int(user),
+            "source_resource_id": int(source_service_id),
+            "target_resource_id": int(target_service_id),
+            "reward": float(reward),
+            "panel": ua["source"]["root"]["type"],
+            "timestamp": ua["timestamp"],
+            "source_path": ua["source"]["page_id"],
+            "target_path": ua["target"]["page_id"],
+            "type": "service",  # currently, static
+            "provider": ["cyfronet", "athena"],  # currently, static
+            "ingestion": "batch",  # currently, static
+        }
+    )
+rsmetrics_db["user_actions"].delete_many(
+    {"provider": provider["name"], "ingestion": "batch"}
+)
+if len(luas) > 0:
+    rsmetrics_db["user_actions"].insert_many(luas)
+
+logging.info("User_actions collection stored...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,5 @@ urllib3==1.26.9
 Werkzeug==2.1.2
 zipp==3.8.0
 flask-pymongo==2.3.0
-pymongoarrow==0.6.2
+pymongoarrow==0.7.0
 flake8==6.0.0

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -137,7 +137,7 @@ rsmetrics_db = datastore[config["datastore"].split("/")[-1]]
 # aggregate_pandas_all
 logging.info("Reading user actions...")
 run.user_actions_all = find_pandas_all(
-    rsmetrics_db["user_actions"], {"provider": 'cyfronet'}
+    rsmetrics_db["user_actions"], {"provider": {"$in": [args.provider]}}
 ).iloc[:, 1:]
 run.user_actions_all.columns = [
     "User",
@@ -152,7 +152,6 @@ run.user_actions_all.columns = [
     "Provider",
     "Ingestion",
 ]
-
 
 logging.info("Reading recommendations...")
 if args.provider == "athena":
@@ -175,7 +174,9 @@ if args.provider == "athena":
                 }
             },
         ],
-    ).iloc[:, 1:]
+    ).iloc[:, 1:-1]
+
+    print(run.recommendations)
 
     run.recommendations.columns = [
         "User",
@@ -340,4 +341,6 @@ jsonstr = json.dumps(output, indent=4)
 rsmetrics_db["metrics"].delete_many({"provider": args.provider})
 rsmetrics_db["metrics"].insert_one(output)
 
-print(jsonstr)
+logging.info(jsonstr)
+logging.info("Metrics computation finished for {}...".format(
+    args.provider))


### PR DESCRIPTION
This PR solved REC-204, where it moves the handling concerning the user_actions from the preprocessor to preprocessor_common.
Meanwhile, the following fixes have been made:

- [x] user_actions have now a list of providers (as all other common collections), instead of one that was before 
- [x] pymongoarrow needs to be updated from 0.6.2 to 0.7.0, since the newer version supports lists extraction when `pandas_find_all` is called. It is mandatory, in order to be able to retrieve user_actions
- [x] `print` statements substituted with `logging.info`
- [x] additional `logging.info` statements have been added for a more readable processing flow