### PR TITLE
REC-211 Collect categories and scientific domains

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,10 +21,4 @@ service:
     # and also in metrics calculations where service is considered
     published: true
 
-    # which origin to use to retrieve Resources
-    # two options available:
-    # - 'source': use the Connector
-    # - 'page_map': use the EOSC Marketplace
-    from: 'page_map' # or 'source'
-
 

--- a/rs-stream.py
+++ b/rs-stream.py
@@ -178,6 +178,10 @@ def main(args):
                               'deleted_on': datetime.fromisoformat(
                                   message['timestamp'].replace('Z', '+00:00'))
                               if message['cud'] == 'delete' else None,
+                              'scientific_domain':
+                              message['record']['scientific_domains'],
+                              'category':
+                              message['record']['categories'],
                               'type': 'service',
                               'provider': ['cyfronet', 'athena'],
                               'ingestion': 'stream'}
@@ -198,6 +202,9 @@ def main(args):
                               'created_on': datetime.fromisoformat(
                                   message['timestamp'].replace('Z', '+00:00')),
                               'deleted_on': None,
+                              'scientific_domain':
+                              message['record']['scientific_domains'],
+                              'category': message['record']['categories'],
                               'type': 'service',
                               'provider': ['cyfronet', 'athena'],
                               'ingestion': 'stream'}


### PR DESCRIPTION
This PR:

- [x] For each service, it collects the associated categories and scientific domains (in terms of ids).
- [x] Stores all categories and scientific domains from Cyfronet's Mongo DB to RS Metrics Datastore.
- [x] The configuration option of choosing between EOSC Marketplace and Cyfronet's Mongo DB is removed. This happened to simplify the process since both EOSC Marketplace and Cyfronet's Mongo DB are needed in order to fill the resources' attributes.
- [x] If no category or scientific_domain is not found for a service in Cyfronet's Mongo DB, then the service's attributes category and scientific_domain are set to null.
- [x] Add the respective code for handling the service as a stream from databus.