### PR TITLE
REC-217 RS Metrics: Top 5 scientific domains for orders

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -10,6 +10,7 @@ class Runtime:
         self.user_actions = None
         self.user_actions_all = None
         self.recommendations = None
+        self.categories = None
         self.provider = None
 
 
@@ -749,6 +750,93 @@ def top5_services_ordered(
         )
 
     return topk_services
+
+
+@metric("The Top 5 recommended categories according to recommendations entries"
+        )
+def top5_categories_recommended(object, k=5, anonymous=False):
+    """
+    Calculate the Top 5 recommended categories according to
+    the recommendations entries.
+    Return a list of list with the elements:
+        #  (i) category id
+        #  (ii) category name (according to category collection)
+        #  (iii) total number of recommendations of the category
+        #  (iv) percentage of the (iii) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+    Category's info is being retrieved from the Cyfronet MongoDB source
+    """
+    # keep recommendations with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    if anonymous:
+        recs = object.recommendations
+    else:
+        recs = object.recommendations[
+            (object.recommendations["user_id"] != -1)
+        ]
+
+    # rename the column at a copy (not in place) for more readable processing
+    _services = object.services.rename(columns={'id': 'resource_id'})
+
+    # create an inner join between the recommendations collection
+    # and the services collection
+    # since a category is a list of category ids
+    # the rows are further expanded (exploded) into rows per category id
+    # inner join means that categories must exist in both services collection
+    # and recommendations collection
+    merged = recs.merge(_services, on='resource_id')
+    exp = merged.explode('category')
+
+    # count categories' ids and covert pandas series to dataframe
+    # user_id holds the same values with all other columns
+    # it is just the first column
+    cat = exp.groupby(["category"])['user_id'].count().to_frame()
+
+    # reset indexes and rename columns accordingly
+    cat = cat.reset_index().rename(columns={'category': 'id',
+                                            'user_id': 'count'})
+
+    # create a second inner join with the categories
+    # in order to retrieve the name of the categories
+    # inner join means that category must exist in both categories collection
+    # and cat collection
+    full_cat = cat.merge(object.categories, on='id')
+
+    # sort based on count
+    # get top k
+    # and convert it to a list of dictionaries
+    # where each dictionary equals to the df's record,
+    # and each column of the df is the key of the dictionary
+    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
+                                orient='records')
+
+    # create similar format to other kpis
+    topk_categories = []
+
+    for category in topk:
+
+        # append a list with the elements:
+        #  (i) category id
+        #  (ii) category name (retrieved from category collection)
+        #  (iii) total number of recommendations of the service
+        #  (iv) percentage of the (iii) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+        topk_categories.append(
+            {
+                "category_id": category['id'],
+                "category_name": category['name'],
+                "recommendations": {
+                    "value": category['count'],
+                    "percentage": round(100 * category['count']
+                                        / len(merged.index), 2),
+                    "of_total": len(merged.index),
+                },
+            }
+        )
+
+    return topk_categories
 
 
 @statistic("A dictionary of the number of recommended items per day")

--- a/metrics.py
+++ b/metrics.py
@@ -789,6 +789,9 @@ def top5_categories_recommended(object, k=5, anonymous=False):
     merged = recs.merge(_services, on='resource_id')
     exp = merged.explode('category')
 
+    # count the total orders where the associated services have categories
+    total = len(merged.dropna(subset=['category']))
+
     # count categories' ids and covert pandas series to dataframe
     # user_id holds the same values with all other columns
     # it is just the first column
@@ -830,9 +833,103 @@ def top5_categories_recommended(object, k=5, anonymous=False):
                 "category_name": category['name'],
                 "recommendations": {
                     "value": category['count'],
-                    "percentage": round(100 * category['count']
-                                        / len(merged.index), 2),
-                    "of_total": len(merged.index),
+                    "percentage": round(100 * category['count'] / total, 2),
+                    "of_total": total,
+                },
+            }
+        )
+
+    return topk_categories
+
+
+@metric("The Top 5 ordered categories according to user actions entries"
+        )
+def top5_categories_ordered(object, k=5, anonymous=False):
+    """
+    Calculate the Top 5 ordered categories according to user actions entries.
+    Return a list of list with the elements:
+        #  (i) category id
+        #  (ii) category name (according to category collection)
+        #  (iii) total number of orders of the category
+        #  (iv) percentage of the (iii) to the total number of orders
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+    Category's info is being retrieved from the Cyfronet MongoDB source
+    """
+    # keep user actions with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    # user_actions with Target Pages that lead to unknown services (=-1)
+    # are being ignored
+    if anonymous:
+        uas = object.user_actions[
+            (object.user_actions["reward"] == 1.0)
+            & (object.user_actions["target_resource_id"] != -1)
+            & (object.user_actions["user_id"] != -1)
+        ]
+    else:
+        uas = object.user_actions[
+            (object.user_actions["reward"] == 1.0)
+            & (object.user_actions["target_resource_id"] != -1)
+        ]
+
+    # rename the column at a copy (not in place) for more readable processing
+    _services = object.services.rename(columns={'id': 'target_resource_id'})
+
+    # create an inner join between the recommendations collection
+    # and the services collection
+    # since a category is a list of category ids
+    # the rows are further expanded (exploded) into rows per category id
+    # inner join means that categories must exist in both services collection
+    # and recommendations collection
+    merged = uas.merge(_services, on='target_resource_id')
+    exp = merged.explode('category')
+
+    # count the total orders where the associated services have categories
+    total = len(merged.dropna(subset=['category']))
+
+    # count categories' ids and covert pandas series to dataframe
+    # user_id holds the same values with all other columns
+    # it is just the first column
+    cat = exp.groupby(["category"])['user_id'].count().to_frame()
+
+    # reset indexes and rename columns accordingly
+    cat = cat.reset_index().rename(columns={'category': 'id',
+                                            'user_id': 'count'})
+
+    # create a second inner join with the categories
+    # in order to retrieve the name of the categories
+    # inner join means that category must exist in both categories collection
+    # and cat collection
+    full_cat = cat.merge(object.categories, on='id')
+
+    # sort based on count
+    # get top k
+    # and convert it to a list of dictionaries
+    # where each dictionary equals to the df's record,
+    # and each column of the df is the key of the dictionary
+    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
+                                orient='records')
+
+    # create similar format to other kpis
+    topk_categories = []
+
+    for category in topk:
+
+        # append a list with the elements:
+        #  (i) category id
+        #  (ii) category name (retrieved from category collection)
+        #  (iii) total number of recommendations of the service
+        #  (iv) percentage of the (iii) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+        topk_categories.append(
+            {
+                "category_id": category['id'],
+                "category_name": category['name'],
+                "recommendations": {
+                    "value": category['count'],
+                    "percentage": round(100 * category['count'] / total, 2),
+                    "of_total": total,
                 },
             }
         )
@@ -875,6 +972,9 @@ def top5_scientific_domains_recommended(object, k=5, anonymous=False):
     # and recommendations collection
     merged = recs.merge(_services, on='resource_id')
     exp = merged.explode('scientific_domain')
+
+    # count the total orders where the associated services have scient. domain
+    total = len(merged.dropna(subset=['scientific_domain']))
 
     # count scientific domains' ids and covert pandas series to dataframe
     # user_id holds the same values with all other columns
@@ -919,8 +1019,8 @@ def top5_scientific_domains_recommended(object, k=5, anonymous=False):
                 "recommendations": {
                     "value": scientific_domain['count'],
                     "percentage": round(100 * scientific_domain['count']
-                                        / len(merged.index), 2),
-                    "of_total": len(merged.index),
+                                        / total, 2),
+                    "of_total": total,
                 },
             }
         )

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -233,6 +233,12 @@ run.categories = pd.DataFrame(
                                    {"_id": 0}))
 )
 
+logging.info("Reading scientific domains...")
+run.scientific_domains = pd.DataFrame(
+                              list(rsmetrics_db["scientific_domain"].find({},
+                                   {"_id": 0}))
+)
+
 data_errors = []
 if len(run.user_actions_all) == 0:
     data_errors.append("No user actions found")
@@ -248,6 +254,9 @@ if len(run.users) == 0:
 
 if len(run.categories) == 0:
     data_errors.append("No categories found")
+
+if len(run.scientific_domains) == 0:
+    data_errors.append("No scientific domains found")
 
 if data_errors:
     for data_error in data_errors:

--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -227,6 +227,12 @@ run.services = pd.DataFrame(
         {"_id": 0}))
 )
 
+logging.info("Reading categories...")
+run.categories = pd.DataFrame(
+                              list(rsmetrics_db["category"].find({},
+                                   {"_id": 0}))
+)
+
 data_errors = []
 if len(run.user_actions_all) == 0:
     data_errors.append("No user actions found")
@@ -239,6 +245,9 @@ if len(run.services) == 0:
 
 if len(run.users) == 0:
     data_errors.append("No users found")
+
+if len(run.categories) == 0:
+    data_errors.append("No categories found")
 
 if data_errors:
     for data_error in data_errors:


### PR DESCRIPTION
- [x] Scientific domains collection is loaded from the Datastore to the main program for the metrics processing
- [x] The KPI `top5_scientific_domains_ordered` is introduced

About the new KPI metric:

- Two inner joins are performed. The first one is for connecting orders with the scientific domain ids and the second join in order to retrieve and associate the scientific domain name to the respective ids. Since it is an inner join, if no association is found, entries are dropped. 
- The total number of orders takes into account those orders that have services with a known scientific domain.