### PR TITLE
REC-225 Fix URL paths and re-add reward mechanism

### DIFF
--- a/preprocessor.py
+++ b/preprocessor.py
@@ -162,13 +162,26 @@ recs = []
 
 if provider["name"] == "cyfronet":
     for rec in recdb["recommendation"].find(query).sort("user"):
-        user = -1
+        # in legacy mode the non-existance of user_id equals to
+        # anonynoums action,
+        # which in rs metrics (legacy mode) is indicated with -1
+        user_id = -1
+        aai_uid = None
+        unique_id = None
         if "user" in rec:
-            user = rec["user"]
+            user_id = rec["user"]
+
+        if "aai_uid" in rec:
+            aai_uid = rec["aai_uid"]
+
+        if "unique_id" in rec:
+            unique_id = str(rec["unique_id"])
 
         recs.append(
             {
-                "user_id": int(user),
+                "user_id": user_id,
+                "aai_uid": aai_uid,
+                "unique_id": unique_id,
                 "resource_ids": rec["services"],
                 "timestamp": rec["timestamp"],
                 "type": "service",  # currently, static
@@ -181,13 +194,26 @@ elif provider["name"] == "athena":
     _query = query.copy()
     _query["date"] = _query.pop("timestamp")
     for rec in recdb["recommendation"].find(_query).sort("user_id"):
-        # if dataset contains null references to user_ids replace them with
-        # the value -1
-        if not rec["user_id"]:
-            rec["user_id"] = -1
+        # in legacy mode the non-existance of user_id equals to
+        # anonynoums action,
+        # which in rs metrics (legacy mode) is indicated with -1
+        user_id = -1
+        aai_uid = None
+        unique_id = None
+        if "user_id" in rec:
+            user_id = rec["user_id"]
+
+        if "aai_uid" in rec:
+            aai_uid = rec["aai_uid"]
+
+        if "unique_id" in rec:
+            unique_id = str(rec["unique_id"])
+
         recs.append(
             {
-                "user_id": int(rec["user_id"]),
+                "user_id": user_id,
+                "aai_uid": aai_uid,
+                "unique_id": unique_id,
                 "resource_ids": list(
                     map(lambda x: x["service_id"], rec["recommendation"])
                 ),

--- a/rs-stream.py
+++ b/rs-stream.py
@@ -63,9 +63,20 @@ def main(args):
             source_path = ""
             target_resource_id = -1
             source_resource_id = -1
-            user_id = -1
+            # in current mode there should be not found user_id=-1
+            # a -1 indicates a legacy mode,
+            # since it is current user_id is set with None
+            user_id = None
+            aai_uid = None
+            unique_id = None
             if "user_id" in message:
                 user_id = message["user_id"]
+
+            if "aai_uid" in message:
+                aai_uid = message["aai_uid"]
+
+            if "unique_id" in message:
+                unique_id = str(message["unique_id"])
 
             if "source" in message:
                 if "page_id" in message["source"]:
@@ -92,6 +103,8 @@ def main(args):
             record = {
                 "timestamp": dateutil.parser.isoparse(message["timestamp"]),
                 "user_id": user_id,
+                "aai_uid": aai_uid,
+                "unique_id": unique_id,
                 "panel": panel,
                 "target_path": target_path,
                 "source_path": source_path,
@@ -245,10 +258,20 @@ def main(args):
         def on_message(self, frame):
             # process the message
             message = json.loads(frame.body)
-
-            user_id = -1
+            # in current mode there should be not found user_id=-1
+            # a -1 indicates a legacy mode,
+            # since it is current user_id is set with None
+            user_id = None
+            aai_uid = None
+            unique_id = None
             if "user_id" in message["context"]:
                 user_id = message["context"]["user_id"]
+
+            if "aai_uid" in message["context"]:
+                aai_uid = message["context"]["aai_uid"]
+
+            if "unique_id" in message["context"]:
+                unique_id = str(message["context"]["unique_id"])
 
             # handle data accordingly
             if provider == "cyfronet":
@@ -256,6 +279,8 @@ def main(args):
                     "timestamp": dateutil.parser.isoparse(
                                  message["context"]["timestamp"]),
                     "user_id": user_id,
+                    "aai_uid": aai_uid,
+                    "unique_id": unique_id,
                     "resource_ids": message["recommendations"],
                     "type": rec_map[message["panel_id"]],
                     "ingestion": "stream",


### PR DESCRIPTION
### On `preprocessor_common.py`:
- URL paths and click transactions are exactly the same as before (including the rewarding mechanism)
- **EXCEPT FOR**:
  - when a user clicks from the search page to a service landing page
  - when a user clicks a recommendation from the search page to a service landing page 
  - there is NO USER ACTION when clicking from a service landing page back to the search menu
- Therefore when catching `search%2F...` regular expression in the source page, then it is swapped with /services.
In the `current` schema, user actions are filled with a `resource_id` attribute. Therefore we use this id to a reverse lookup table in order to find the correct page.
- Preprocessing is backward compatible for the new exceptions (so reward and URL paths are always fixed)


Important: In order to calculate the reward, the trailing slash needs to be removed from both the source and target pages.

### On `rs-stream.py`:
- Is also backward compatible as `preprocessor_common.py`
- The same reward mechanism (as in preprocessor_common.py) has been added
