### PR TITLE
REC-252 Wherever referenced: change services to items

### DIFF
--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -235,8 +235,8 @@ else:
 run.recommendations.rename(columns={'resource_ids': 'resource_id'},
                            inplace=True)
 
-logging.info("Reading services...")
-run.services = pd.DataFrame(
+logging.info("Reading items...")
+run.items = pd.DataFrame(
     list(rsmetrics_db["resources"].find({
         "$and": [
             {"provider": {"$in": [args.provider]}},
@@ -300,23 +300,23 @@ try:
         pd.to_datetime(run.user_actions_all["timestamp"])
     )
 
-    # remove user actions when service does not exist in services' catalog
-    # not-known services (i.e. -1) are not excluded
+    # remove user actions when item does not exist in items' catalog
+    # not-known items (i.e. -1) are not excluded
     # (there is no need to do this for users, since users are already
     # built upon user actions)
     # also a source_resource_id or target_resource_id will always be
     # an integer (-1 indicates not known)
     run.user_actions = run.user_actions_all[
         (run.user_actions_all["source_resource_id"]
-         .isin(run.services["id"].tolist() + [-1]))
+         .isin(run.items["id"].tolist() + [-1]))
     ]
     run.user_actions = run.user_actions[
         (run.user_actions["target_resource_id"]
-         .isin(run.services["id"].tolist() + [-1]))
+         .isin(run.items["id"].tolist() + [-1]))
     ]
 
     # converts resource_id from string to integer
-    # this is not necessary in resource_ids in user actions or services
+    # this is not necessary in resource_ids in user actions or items
     run.recommendations['resource_id'] = \
         run.recommendations['resource_id'].astype(int)
 
@@ -325,10 +325,10 @@ try:
     )
 
     # remove recommendations when user or service does not exist in users' or
-    # services' catalogs
+    # items' catalogs
     # anonymous users (i.e. -1 or None in legacy or current mode respectively)
     # are not excluded
-    # not-known services (i.e. -1) are not excluded
+    # not-known items (i.e. -1) are not excluded
     # (having both -1 and None cover both schemas -current or legacy-)
     # meanwhile, current schema can not have -1 while legacy None,
     # so there is no issue to filter both entries concurrently
@@ -339,7 +339,7 @@ try:
 
     run.recommendations = run.recommendations[
         (run.recommendations["resource_id"]
-         .isin(run.services["id"].tolist() + [-1]))
+         .isin(run.items["id"].tolist() + [-1]))
     ]
 
 except Exception as e:
@@ -353,7 +353,7 @@ if len(run.user_actions_all) == 0:
 if len(run.recommendations) == 0:
     data_errors.append("No recommendations found")
 
-if len(run.services) == 0:
+if len(run.items) == 0:
     data_errors.append("No services found")
 
 if len(run.users) == 0:

--- a/webservice/app.py
+++ b/webservice/app.py
@@ -134,7 +134,7 @@ def html_metrics(report_name):
     stats_needed = [
         "users",
         "recommended_items",
-        "services",
+        "items",
         "user_actions",
         "user_actions_registered",
         "user_actions_registered_perc",
@@ -190,8 +190,8 @@ def html_kpis(report_name):
     metrics_needed = [
         "hit_rate",
         "click_through_rate",
-        "top5_services_ordered",
-        "top5_services_recommended",
+        "top5_items_ordered",
+        "top5_items_recommended",
         "top5_categories_ordered",
         "top5_categories_recommended",
         "top5_scientific_domains_ordered",

--- a/webservice/templates/kpis.html
+++ b/webservice/templates/kpis.html
@@ -260,7 +260,7 @@
                                             </h4>
                                         </div>
                                         <div class="widget-subheading">The ratio of user hits divided by the total
-                                            number of users (user hit: a user that has accessed at least one service
+                                            number of users (user hit: a user that has accessed at least one item
                                             that is also a personal recommendation)</div>
                                     </div>
                                     <div class="widget-content-right">
@@ -279,15 +279,15 @@
                         <div class="col-md-6">
                             <div class="main-card mb-3 card">
                                 <div class="card-body">
-                                    <h5 class="card-title">Top 5 recommended services</h5>
+                                    <h5 class="card-title">Top 5 recommended items</h5>
                                     <p>
 
-                                        {% for item in data.top5_services_recommended.value %}
+                                        {% for item in data.top5_items_recommended.value %}
                                     <div class="card-shadow-info mb-3 widget-chart widget-chart2 text-start card">
                                         <div class="row">
                                             <div class="widget-content col-md-10">
                                                 <h4><b>#{{loop.index}}</b> <a
-                                                        href="{{item.service_url}}">{{item.service_name}}</a></h4>
+                                                        href="{{item.item_url}}">{{item.item_name}}</a></h4>
                                                 <hr>
                                                 </hr>
                                                 <div class="widget-content-outer">
@@ -335,15 +335,15 @@
                         <div class="col-md-6">
                             <div class="main-card mb-3 card">
                                 <div class="card-body">
-                                    <h5 class="card-title">Top 5 ordered services</h5>
+                                    <h5 class="card-title">Top 5 ordered items</h5>
                                     <p>
 
-                                        {% for item in data.top5_services_ordered.value %}
+                                        {% for item in data.top5_items_ordered.value %}
                                     <div class="card-shadow-info mb-3 widget-chart widget-chart2 text-start card">
                                         <div class="row">
                                             <div class="widget-content col-md-10">
                                                 <h4><b>#{{loop.index}}</b> <a
-                                                        href="{{item.service_url}}">{{item.service_name}}</a></h4>
+                                                        href="{{item.item_url}}">{{item.item_name}}</a></h4>
                                                 <hr>
                                                 </hr>
                                                 <div class="widget-content-outer">
@@ -401,7 +401,7 @@
                                         <div class="row">
                                             <div class="widget-content col-md-10">
                                                 <h4><b>#{{loop.index}}</b> <a
-                                                        href="{{item.service_url}}">{{item.category_name}}</a></h4>
+                                                        href="{{item.item_url}}">{{item.category_name}}</a></h4>
                                                 <hr>
                                                 </hr>
                                                 <div class="widget-content-outer">
@@ -457,7 +457,7 @@
                                         <div class="row">
                                             <div class="widget-content col-md-10">
                                                 <h4><b>#{{loop.index}}</b> <a
-                                                        href="{{item.service_url}}">{{item.category_name}}</a></h4>
+                                                        href="{{item.item_url}}">{{item.category_name}}</a></h4>
                                                 <hr>
                                                 </hr>
                                                 <div class="widget-content-outer">
@@ -515,7 +515,7 @@
                                         <div class="row">
                                             <div class="widget-content col-md-10">
                                                 <h4><b>#{{loop.index}}</b> <a
-                                                        href="{{item.service_url}}">{{item.scientific_domain_name}}</a></h4>
+                                                        href="{{item.item_url}}">{{item.scientific_domain_name}}</a></h4>
                                                 <hr>
                                                 </hr>
                                                 <div class="widget-content-outer">
@@ -571,7 +571,7 @@
                                         <div class="row">
                                             <div class="widget-content col-md-10">
                                                 <h4><b>#{{loop.index}}</b> <a
-                                                        href="{{item.service_url}}">{{item.scientific_domain_name}}</a></h4>
+                                                        href="{{item.item_url}}">{{item.scientific_domain_name}}</a></h4>
                                                 <hr>
                                                 </hr>
                                                 <div class="widget-content-outer">

--- a/webservice/templates/rsmetrics.html
+++ b/webservice/templates/rsmetrics.html
@@ -241,11 +241,11 @@
                                             <div class="widget-content-outer">
                                                 <div class="widget-content-wrapper">
                                                     <div class="widget-content-left">
-                                                        <div class="widget-heading">Services</div>
-                                                        <div class="widget-subheading">{{data.services.doc}}</div>
+                                                        <div class="widget-heading">Items</div>
+                                                        <div class="widget-subheading">{{data.items.doc}}</div>
                                                     </div>
                                                     <div class="widget-content-right">
-                                                        <div class="widget-numbers text-primary">{{data.services.value}}
+                                                        <div class="widget-numbers text-primary">{{data.items.value}}
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
# 🎯 Goal
Since we are creating evaluations for different types of items (and not just "services") change hardcoded references to `services` to be more generic and replace them with `items`

# 🏗️ Implementation
- [x] In order to change references to api and ui we need to change references to the produced results. Change `service` refs into `items` in `metrics.py` and `rsmetrics.py` code
- [x] Change refs in `app.py` (api)
- [x] Change refs in html templates