### PR TITLE
REC-256 Fix statistic:items reference in jinja template

### DIFF
--- a/webservice/templates/rsmetrics.html
+++ b/webservice/templates/rsmetrics.html
@@ -242,10 +242,10 @@
                                                 <div class="widget-content-wrapper">
                                                     <div class="widget-content-left">
                                                         <div class="widget-heading">Items</div>
-                                                        <div class="widget-subheading">{{data.items.doc}}</div>
+                                                        <div class="widget-subheading">{{data['items'].doc}}</div>
                                                     </div>
                                                     <div class="widget-content-right">
-                                                        <div class="widget-numbers text-primary">{{data.items.value}}
+                                                        <div class="widget-numbers text-primary">{{data['items'].value}}
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
Reference `items` statistic in data as `data['items']` to avoid jinja/python confict with items dictionary method 