### PR TITLE
REC-248 Support evaluation of training material

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,10 +6,12 @@ providers:
      db: "mongodb://localhost:27017/recommender_dev"
    - name: athena
      db: "mongodb://localhost:27017/athena_dev"
+   - name: online_engine
+     db: ""
 
 # The database where the Preprocessor's
 # and RSmetrics data are stored
-datastore: "mongodb://localhost:27017/rsmetrics"
+datastore: "mongodb://localhost:27017/rsmetrics2"
 
 service:
     # Use the EOSC-Marketplace webpage

--- a/metrics.py
+++ b/metrics.py
@@ -303,954 +303,12 @@ def total_unique_recommended_items(object):
     return int(object.recommendations.nunique()["resource_id"])
 
 
-@metric("The percentage (%) of unique items  to the total number "
-        "of items")
-def catalog_coverage(object):
-    """
-    Calculate the percentage (%) of unique items
-    found to the total number of items
-    """
-    return round((total_unique_recommended_items(object) * 100.0 /
-                  items(object)), 2)
-
-
 @statistic("The total number of unique users found in recommendations")
 def total_unique_users_recommended(object):
     """
     Calculate the total number of unique users found in recommendations
     """
     return int(object.recommendations.nunique()[object.id_field])
-
-
-@metric("The percentage (%) of unique users to the total number of users")
-def user_coverage(object):
-    """
-    Calculate the percentage (%) of unique users  to the total number of users
-    """
-    return round((total_unique_users_recommended(object) * 100.0 /
-                  users(object)), 2)
-
-
-@metric(
-    "The ratio of user hits divided by the total number of users "
-    "(user hit: a user that has accessed at least one item "
-    "that is also a personal recommendation)"
-)
-def hit_rate(object):
-    """
-    1) For each user get the recommended items and the items the user
-    accessed
-    2) Check if the user has at least one accessed item in recommendations
-    3) If yes increase number of hits by one
-    4) Divide by the total number of users
-    """
-    users = object.users.values.tolist()
-    recs = object.recommendations.values.tolist()
-    # Fill lookup dictionary with all items recommender per user id
-    user_recs = dict()
-    for item in recs:
-        # skip anonymous users
-        if item == -1:
-            continue
-        user_id = item[0]
-        item_id = item[1]
-        if user_id in user_recs.keys():
-            user_recs[user_id].append(item_id)
-        else:
-            user_recs[user_id] = [item_id]
-
-    hits = 0
-    # For each user in users check if his accessed items are in
-    # his recommendations
-
-    for user in users:
-        user_id = user[0]
-        # create a set of unique accessed items by user
-        items = set(user[1])
-        if user_id in user_recs.keys():
-            # create a set of unique recommended items to the user
-            recommendations = set(user_recs.get(user_id))
-            # intersection should include items that have been both
-            # accessed by and recommended to the user
-            intersection = items.intersection(recommendations)
-            # If the user has at least one item (both recommended and
-            # accessed), this user is considered a hit
-            if len(intersection) > 0:
-                hits = hits + 1
-
-    return round(hits / len(users), 5)
-
-
-@metric(
-    "The number of user clicks through recommendations panels divided by the "
-    "total times recommendation panels were presented to users. "
-    "Takes into account all historical data of user actions"
-)
-def click_through_rate(object):
-    """
-    Get only the user actions that present a recommendation panel to the user
-    in the source page
-    Those are actions with the following source paths:
-     - /services
-     - /services/
-     - /services/c/{any category name}
-    1) Count the items in above list as they represent the times
-    recommendations panels were
-    presented to the users of the portal
-    2) Narrow the above list into a new subset by selecting only user actions
-    that originate
-    from a recommendation panel
-    3) Those are actions that have the 'recommendation' string in the
-    Action column
-    4) Count the items in the subset as they represent the times users clicked
-    through recommendations
-    5) Divide the items of the subset with the items of the first list to get
-    the click-through rate
-    """
-
-    # get user actions
-    user_actions_recpanel_views = object.user_actions[
-        object.user_actions['source_path'].isin(
-            ['/services', '/services/']
-        ) |
-        object.user_actions['source_path'].str.startswith('/services/c/')
-    ]
-
-    user_actions_recpanel_clicks = user_actions_recpanel_views[
-        user_actions_recpanel_views['panel'] == 'recommendation_panel'
-    ]
-    try:
-        return round(
-            len(user_actions_recpanel_clicks)
-            / len(user_actions_recpanel_views), 2
-        )
-    except ZeroDivisionError:
-        return 0.00
-
-
-@metric(
-    "The diversity of the recommendations according to Shannon Entropy. "
-    "The entropy is 0 when a single item is always chosen or recommended, "
-    "and log n when n items are chosen or recommended equally often."
-)
-def diversity(object, anonymous=False):
-    """
-    Calculate Shannon Entropy. The entropy is 0 when a single item is always
-    chosen or recommended, and log n when n items are chosen or recommended
-    equally often.
-    """
-    # keep recommendations with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    if anonymous:
-        recs = object.recommendations
-    else:
-        recs = object.recommendations[
-            (object.recommendations[object.id_field]
-                .find_registered(object.schema))
-        ]
-
-    # this variable keeps the sum of user_norm (where user_norm is
-    # the count of how many times a User has been suggested)
-    # however since no cutoff at per user recommendations is applied and
-    # also since each recommendation entry is one-to-one <user id> <item id>
-    # then the total number of recommendations is equal to this sum
-
-    # remember that recommendations have been previously filtered based
-    # on the existance of users and items
-
-    # item_count
-    # group recommendations entries by item id and
-    # then count how many times each item has been suggested
-    gr_item = recs.groupby(["resource_id"]).count()
-
-    # create a dictionary of item_count in order to
-    # map the item id to the respective item_count
-    # key=<item id> and value=<item_count>
-    d_item = gr_item[object.id_field].to_dict()
-
-    # each element represent the item's recommendations occurance
-    # e.g. [1,6,7]
-    # a item was recommended 1 time, another 6 times and another 7 times
-    items = np.array(list(d_item.values()))
-
-    # the total number of recommendations
-    n_recommendations = items.sum()
-
-    # element-wise computations
-    # (division for each item's recommendations occurance)
-    recommended_probability = items / n_recommendations
-
-    # H=-Sum(p*logp) [element-wise]
-    shannon_entropy = -np.sum(
-        recommended_probability * np.log2(recommended_probability)
-    )
-
-    return round(shannon_entropy, 4)
-
-
-@metric("The novelty expresses how often new and unseen items are"
-        " recommended to users")
-def novelty(object):
-    """Calculate novelty of recommendations
-    using the n=SUM(-log(p(i)))/|R| formula"""
-    # published items
-    items_pub = object.items["id"]
-    # recommended items to authenticated users
-    items_rec = (object
-                 .recommendations[object.recommendations[object.id_field]
-                                  .find_registered(
-                                     object.schema)]["resource_id"])
-
-    # items that are published and recommended
-    items_recpub = items_rec[items_rec
-                             .isin(items_pub)].drop_duplicates()
-
-    # user actions
-    ua = object.user_actions
-    # user actions filtered if src and target the same. Also filter out
-    # if target equals -1 and filter out anonymous users
-    ua_serv_view = ua[
-        (ua["source_resource_id"] != ua["target_resource_id"])
-        & (ua["target_resource_id"] != -1)
-        & (ua[object.id_field].find_registered(object.schema))
-    ]
-
-    # count item views by item id (sorted by item id)
-    items_viewed = (ua_serv_view["target_resource_id"]
-                    .value_counts().sort_index())
-
-    # create a table for each recommended item with columns
-    # for number of views, p(i) and -log(pi)
-    r_items = pd.DataFrame(index=items_recpub).sort_index()
-    # add views column to assign views to each recommended item
-    r_items["views"] = items_viewed
-
-    # count the total item views in order to compute the portions p(i)
-    total_views = r_items["views"].sum()
-
-    # count the total recommended items |R|
-    total_items = len(r_items)
-    # compute the p(i) of each recommeneded item
-    r_items["pi"] = r_items["views"] / total_views
-    # calculate the negative log of the p(i).
-    r_items["-logpi"] = -1 * np.log2(r_items["pi"])
-
-    # calculate novelty based on formula n=SUM(-log(p(i)))/|R|
-    novelty = r_items["-logpi"].sum() / total_items
-
-    return round(novelty, 4)
-
-
-@metric(
-    "The diversity of the recommendations according to GiniIndex. "
-    "The index is 0 when all items are "
-    "chosen equally often, and 1 when a single item is always chosen."
-)
-def diversity_gini(object, anonymous=False):
-    """
-    Calculate GiniIndex based on
-    https://elliot.readthedocs.io/en/latest/_modules/elliot/evaluation
-    /metrics/diversity/gini_index/gini_index.html#GiniIndex
-    (see book https://link.springer.com/10.1007/978-1-4939-7131-2_110158)
-    """
-    # keep recommendations with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    if anonymous:
-        recs = object.recommendations
-    else:
-        recs = object.recommendations[
-            (object.recommendations[object.id_field]
-                .find_registered(object.schema))
-        ]
-    # this variable keeps the sum of user_norm (where user_norm is
-    # the count of how many times a User has been suggested)
-    # however since no cutoff at per user recommendations is applied and
-    # also since each recommendation entry is one-to-one <user id> <item id>
-    # then the total number of recommendations is equal to this sum
-    free_norm = len(recs.index)
-
-    # item_count
-    # group recommendations entries by item id and
-    # then count how many times each item has been suggested
-    gr_item = recs.groupby(["resource_id"]).count()
-
-    # create a dictionary of item_count in order to
-    # map the item id to the respective item_count
-    # key=<item id> and value=<item_count>
-    d_item = gr_item[object.id_field].to_dict()
-
-    # total number of recommended itemss
-    n_recommended_items = len(d_item)
-
-    # total number of items
-    num_items = items(object)
-
-    # create a zero list
-    # to calculate gini index including elements with 0 occurance
-    zeros = [0] * (num_items - n_recommended_items)
-
-    gini = sum(
-        [
-            (2 * (j + 1) - num_items - 1) * (cs / free_norm)
-            for j, cs in enumerate(zeros + sorted(d_item.values()))
-        ]
-    )
-
-    gini /= num_items - 1
-
-    return round(gini, 4)
-
-
-@metric("The Top 5 recommended items according to recommendations entries")
-def top5_items_recommended(
-    object, k=5, base="https://marketplace.eosc-portal.eu", anonymous=False
-):
-    """
-    Calculate the Top 5 recommended items according to
-    the recommendations entries.
-    Return a list of list with the elements:
-        #   (i) item id
-        #  (ii) item name
-        # (iii) item page appended with base (to create the URL)
-        #  (iv) total number of recommendations of the item
-        #   (v) percentage of the (iv) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-    Item's info is being retrieved from the external source
-    (i.e. each line forms: item_id, item_name, page_id)
-    """
-    # keep recommendations with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    if anonymous:
-        recs = object.recommendations
-    else:
-        recs = object.recommendations[
-            (object.recommendations[object.id_field]
-                .find_registered(object.schema))
-        ]
-
-    # item_count
-    # group recommendations entries by item id and
-    # then count how many times each item has been suggested
-    gr_item = recs.groupby(["resource_id"]).count()
-
-    # create a dictionary of item_count in order to
-    # map the item id to the respective item_count
-    # key=<item id> and value=<item_count>
-    d_item = gr_item[object.id_field].to_dict()
-
-    # convert dictionary to double list (list of lists)
-    # where the sublist is <item_id> <item_count>
-    # and sort them from max to min <item_count>
-    l_item = list(map(lambda x: [x, d_item[x]], d_item))
-    l_item.sort(key=lambda x: x[1], reverse=True)
-
-    # get only the first k elements
-    l_item = l_item[:k]
-
-    topk_items = []
-
-    for item in l_item:
-        # get item's info from dataframe
-        _df_item = (object
-                    .items[(object
-                            .items["id"]
-                            .isin([item[0]]))])
-
-        # append a list with the elements:
-        #   (i) item id
-        #  (ii) item name
-        # (iii) item page appended with base (to create the URL)
-        #  (iv) total number of recommendations of the item
-        #   (v) percentage of the (iv) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-        topk_items.append(
-            {
-                "item_id": item[0],
-                "item_name": str(_df_item["name"].item()),
-                "item_url": base + str(_df_item["path"].item()),
-                "recommendations": {
-                    "value": item[1],
-                    "percentage": round(100 * item[1] / len(recs.index), 2),
-                    "of_total": len(recs.index),
-                },
-            }
-        )
-
-    return topk_items
-
-
-@metric("The Top 5 ordered items according to user actions entries")
-def top5_items_ordered(
-    object, k=5, base="https://marketplace.eosc-portal.eu", anonymous=False
-):
-    """
-    Calculate the Top 5 ordered items according to user actions entries.
-    User actions with Target Pages that lead to unknown items (=-1)
-    are being ignored.
-    Return a list of list with the elements:
-        #   (i) item id
-        #  (ii) item name
-        # (iii) item page appended with base (to create the URL)
-        #  (iv) total number of orders of the item
-        #   (v) percentage of the (iv) to the total number of orders
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-    """
-    # keep user actions with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    # user_actions with Target Pages that lead to unknown items (=-1)
-    # are being ignored
-    if anonymous:
-        uas = object.user_actions[
-            (object.user_actions["reward"] == 1.0)
-            & (object.user_actions["target_resource_id"] != -1)
-            & (object.user_actions[object.id_field]
-                .find_registered(object.schema))
-        ]
-    else:
-        uas = object.user_actions[
-            (object.user_actions["reward"] == 1.0)
-            & (object.user_actions["target_resource_id"] != -1)
-        ]
-
-    # item_count
-    # group user_actions entries by item id and
-    # then count how many times each item has been suggested
-    gr_item = uas.groupby(["target_resource_id"]).count()
-
-    # create a dictionary of item_count in order to
-    # map the item id to the respective item_count
-    # key=<item id> and value=<item_count>
-    d_item = gr_item[object.id_field].to_dict()
-
-    # convert dictionary to double list (list of lists)
-    # where the sublist is <item_id> <item_count>
-    # and sort them from max to min <item_count>
-    l_item = list(map(lambda x: [x, d_item[x]], d_item))
-    l_item.sort(key=lambda x: x[1], reverse=True)
-
-    # get only the first k elements
-    l_item = l_item[:k]
-
-    topk_items = []
-
-    for item in l_item:
-        # get items's info from dataframe
-        _df_item = object.item[object.items["id"]
-                                     .isin([item[0]])]
-        # append a list with the elements:
-        #   (i) item id
-        #  (ii) item name
-        # (iii) item page appended with base (to create the URL)
-        #  (iv) total number of orders of the item
-        #   (v) percentage of the (iv) to the total number of orders
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-        topk_items.append(
-            {
-                "item_id": item[0],
-                "item_name": str(_df_item["name"].item()),
-                "item_url": base + str(_df_item["path"].item()),
-                "orders": {
-                    "value": item[1],
-                    "percentage": round(100 * item[1] / len(uas.index), 2),
-                    "of_total": len(uas.index),
-                },
-            }
-        )
-
-    return topk_items
-
-
-@metric("The Top 5 recommended categories according to recommendations entries"
-        )
-def top5_categories_recommended(object, k=5, anonymous=False):
-    """
-    Calculate the Top 5 recommended categories according to
-    the recommendations entries.
-    Return a list of list with the elements:
-        #  (i) category id
-        #  (ii) category name (according to category collection)
-        #  (iii) total number of recommendations of the category
-        #  (iv) percentage of the (iii) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-    Category's info is being retrieved from the marketplace_rs MongoDB source
-    """
-    # keep recommendations with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    if anonymous:
-        recs = object.recommendations
-    else:
-        recs = object.recommendations[
-            (object.recommendations[object.id_field]
-                .find_registered(object.schema))
-        ]
-
-    # rename the column at a copy (not in place) for more readable processing
-    _items = object.items.rename(columns={'id': 'resource_id'})
-
-    # create an inner join between the recommendations collection
-    # and the items collection
-    # since a category is a list of category ids
-    # the rows are further expanded (exploded) into rows per category id
-    # inner join means that categories must exist in both items collection
-    # and recommendations collection
-    merged = recs.merge(_items, on='resource_id')
-    exp = merged.explode('category')
-
-    # count the total orders where the associated items have categories
-    total = len(merged.dropna(subset=['category']))
-
-    # count categories' ids and covert pandas series to dataframe
-    # user_id holds the same values with all other columns
-    # it is just the first column
-    cat = exp.groupby(["category"])[object.id_field].count().to_frame()
-
-    # reset indexes and rename columns accordingly
-    cat = cat.reset_index().rename(columns={'category': 'id',
-                                            object.id_field: 'count'})
-
-    # create a second inner join with the categories
-    # in order to retrieve the name of the categories
-    # inner join means that category must exist in both categories collection
-    # and cat collection
-    full_cat = cat.merge(object.categories, on='id')
-
-    # sort based on count
-    # get top k
-    # and convert it to a list of dictionaries
-    # where each dictionary equals to the df's record,
-    # and each column of the df is the key of the dictionary
-    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
-                                orient='records')
-
-    # create similar format to other kpis
-    topk_categories = []
-
-    for category in topk:
-
-        # append a list with the elements:
-        #  (i) category id
-        #  (ii) category name (retrieved from category collection)
-        #  (iii) total number of recommendations of the item
-        #  (iv) percentage of the (iii) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-        topk_categories.append(
-            {
-                "category_id": category['id'],
-                "category_name": category['name'],
-                "recommendations": {
-                    "value": category['count'],
-                    "percentage": round(100 * category['count'] / total, 2),
-                    "of_total": total,
-                },
-            }
-        )
-
-    return topk_categories
-
-
-@metric("The Top 5 ordered categories according to user actions entries"
-        )
-def top5_categories_ordered(object, k=5, anonymous=False):
-    """
-    Calculate the Top 5 ordered categories according to user actions entries.
-    Return a list of list with the elements:
-        #  (i) category id
-        #  (ii) category name (according to category collection)
-        #  (iii) total number of orders of the category
-        #  (iv) percentage of the (iii) to the total number of orders
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-    Category's info is being retrieved from the marketplace_rs MongoDB source
-    """
-    # keep user actions with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    # user_actions with Target Pages that lead to unknown items (=-1)
-    # are being ignored
-    if anonymous:
-        uas = object.user_actions[
-            (object.user_actions["reward"] == 1.0)
-            & (object.user_actions["target_resource_id"] != -1)
-            & (object.user_actions[object.id_field]
-                .find_registered(object.schema))
-        ]
-    else:
-        uas = object.user_actions[
-            (object.user_actions["reward"] == 1.0)
-            & (object.user_actions["target_resource_id"] != -1)
-        ]
-
-    # rename the column at a copy (not in place) for more readable processing
-    _items = object.items.rename(columns={'id': 'target_resource_id'})
-
-    # create an inner join between the recommendations collection
-    # and the items collection
-    # since a category is a list of category ids
-    # the rows are further expanded (exploded) into rows per category id
-    # inner join means that categories must exist in both items collection
-    # and recommendations collection
-    merged = uas.merge(_items, on='target_resource_id')
-    exp = merged.explode('category')
-
-    # count the total orders where the associated items have categories
-    total = len(merged.dropna(subset=['category']))
-
-    # count categories' ids and covert pandas series to dataframe
-    # user_id holds the same values with all other columns
-    # it is just the first column
-    cat = exp.groupby(["category"])[object.id_field].count().to_frame()
-
-    # reset indexes and rename columns accordingly
-    cat = cat.reset_index().rename(columns={'category': 'id',
-                                            object.id_field: 'count'})
-
-    # create a second inner join with the categories
-    # in order to retrieve the name of the categories
-    # inner join means that category must exist in both categories collection
-    # and cat collection
-    full_cat = cat.merge(object.categories, on='id')
-
-    # sort based on count
-    # get top k
-    # and convert it to a list of dictionaries
-    # where each dictionary equals to the df's record,
-    # and each column of the df is the key of the dictionary
-    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
-                                orient='records')
-
-    # create similar format to other kpis
-    topk_categories = []
-
-    for category in topk:
-
-        # append a list with the elements:
-        #  (i) category id
-        #  (ii) category name (retrieved from category collection)
-        #  (iii) total number of recommendations of the item
-        #  (iv) percentage of the (iii) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-        topk_categories.append(
-            {
-                "category_id": category['id'],
-                "category_name": category['name'],
-                "orders": {
-                    "value": category['count'],
-                    "percentage": round(100 * category['count'] / total, 2),
-                    "of_total": total,
-                },
-            }
-        )
-
-    return topk_categories
-
-
-@metric("The Top 5 recommended scientific domains according to recommendations\
-entries")
-def top5_scientific_domains_recommended(object, k=5, anonymous=False):
-    """
-    Calculate the Top 5 recommended scientific domains according to
-    the recommendations entries.
-    Return a list of list with the elements:
-    #  (i) scientific domain id
-    #  (ii) scientific domain name (according to scientific_domain collection)
-    #  (iii) total number of recommendations of the scientific domain
-    #  (iv) percentage of the (iii) to the total number of recommendations
-    #       expressed in %, with or without anonymous,
-    #       based on the function's flag
-    Scientif. domain's info is being retrieved from the marketplace_rs
-    MongoDB source
-    """
-    # keep recommendations with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    if anonymous:
-        recs = object.recommendations
-    else:
-        recs = object.recommendations[
-            (object.recommendations[object.id_field]
-                .find_registered(object.schema))
-        ]
-
-    # rename the column at a copy (not in place) for more readable processing
-    _items = object.items.rename(columns={'id': 'resource_id'})
-
-    # create an inner join between the recommendations collection
-    # and the items collection
-    # since a scientific domain is a list of scientific domain ids
-    # the rows are further expanded (exploded) into rows per scient. domain id
-    # inner join means that scient. domains must exist in both items
-    # and recommendations collection
-    merged = recs.merge(_items, on='resource_id')
-    exp = merged.explode('scientific_domain')
-
-    # count the total orders where the associated items have scient. domain
-    total = len(merged.dropna(subset=['scientific_domain']))
-
-    # count scientific domains' ids and covert pandas series to dataframe
-    # user_id holds the same values with all other columns
-    # it is just the first column
-    cat = exp.groupby(["scientific_domain"])[
-        object.id_field].count().to_frame()
-
-    # reset indexes and rename columns accordingly
-    cat = cat.reset_index().rename(columns={'scientific_domain': 'id',
-                                            object.id_field: 'count'})
-
-    # create a second inner join with the scientific domains
-    # in order to retrieve the name of the scientific domains
-    # inner join means that scientific domain must exist in both
-    # scientific domains collection and cat collection
-    full_cat = cat.merge(object.scientific_domains, on='id')
-
-    # sort based on count
-    # get top k
-    # and convert it to a list of dictionaries
-    # where each dictionary equals to the df's record,
-    # and each column of the df is the key of the dictionary
-    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
-                                orient='records')
-
-    # create similar format to other kpis
-    topk_scientific_domains = []
-
-    for scientific_domain in topk:
-
-        # append a list with the elements:
-        #  (i) scientific domains id
-        #  (ii) scientific domains name (retrieved from
-        #                                scientific_domain collection)
-        #  (iii) total number of recommendations of the item
-        #  (iv) percentage of the (iii) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-        topk_scientific_domains.append(
-            {
-                "scientific_domain_id": scientific_domain['id'],
-                "scientific_domain_name": scientific_domain['name'],
-                "recommendations": {
-                    "value": scientific_domain['count'],
-                    "percentage": round(100 * scientific_domain['count']
-                                        / total, 2),
-                    "of_total": total,
-                },
-            }
-        )
-
-    return topk_scientific_domains
-
-
-@metric("The Top 5 ordered scientific domains according to user actions \
-entries")
-def top5_scientific_domains_ordered(object, k=5, anonymous=False):
-    """
-    Calculate the Top 5 ordered sc. domains according to user actions entries.
-    Return a list of list with the elements:
-        #  (i) scientific domain id
-        #  (ii) sc. domain name (according to scientific domain collection)
-        #  (iii) total number of orders of the scientific domain
-        #  (iv) percentage of the (iii) to the total number of orders
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-    Sc. domain's info is being retrieved from the marketplace_rs MongoDB source
-    """
-    # keep user actions with or without anonymous suggestions
-    # based on anonymous flag (default=False, i.e. ignore anonymous)
-    # user_actions with Target Pages that lead to unknow items (=-1)
-    # are being ignored
-    if anonymous:
-        uas = object.user_actions[
-            (object.user_actions["reward"] == 1.0)
-            & (object.user_actions["target_resource_id"] != -1)
-            & (object.user_actions[object.id_field].find_registered(
-                  object.schema))
-        ]
-    else:
-        uas = object.user_actions[
-            (object.user_actions["reward"] == 1.0)
-            & (object.user_actions["target_resource_id"] != -1)
-        ]
-
-    # rename the column at a copy (not in place) for more readable processing
-    _items = object.items.rename(columns={'id': 'target_resource_id'})
-
-    # create an inner join between the recommendations collection
-    # and the items collection
-    # since a scientific domain is a list of scientific domain ids
-    # the rows are further expanded (exploded) into rows per sc. domain id
-    # inner join means that sc. domains must exist in both items collection
-    # and recommendations collection
-    merged = uas.merge(_items, on='target_resource_id')
-    exp = merged.explode('scientific_domain')
-
-    # count the total orders where the associated items have sc. domains
-    total = len(merged.dropna(subset=['scientific_domain']))
-
-    # count scientific domains' ids and covert pandas series to dataframe
-    # user_id holds the same values with all other columns
-    # it is just the first column
-    cat = exp.groupby(["scientific_domain"])[
-        object.id_field].count().to_frame()
-
-    # reset indexes and rename columns accordingly
-    cat = cat.reset_index().rename(columns={'scientific_domain': 'id',
-                                            object.id_field: 'count'})
-
-    # create a second inner join with the scientific domains
-    # in order to retrieve the name of the scientific domains
-    # inner join means that sc. domain must exist in both sc. domains
-    # and cat collection
-    full_cat = cat.merge(object.scientific_domains, on='id')
-
-    # sort based on count
-    # get top k
-    # and convert it to a list of dictionaries
-    # where each dictionary equals to the df's record,
-    # and each column of the df is the key of the dictionary
-    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
-                                orient='records')
-
-    # create similar format to other kpis
-    topk_scientific_domains = []
-
-    for scientific_domain in topk:
-
-        # append a list with the elements:
-        #  (i) scientific_domain id
-        #  (ii) scientific_domain name (retrieved from
-        #                               scientific_domain collection)
-        #  (iii) total number of recommendations of the item
-        #  (iv) percentage of the (iii) to the total number of recommendations
-        #       expressed in %, with or without anonymous,
-        #       based on the function's flag
-        topk_scientific_domains.append(
-            {
-                "scientific_domain_id": scientific_domain['id'],
-                "scientific_domain_name": scientific_domain['name'],
-                "orders": {
-                    "value": scientific_domain['count'],
-                    "percentage": round(100 * scientific_domain['count']
-                                        / total, 2),
-                    "of_total": total,
-                },
-            }
-        )
-
-    return topk_scientific_domains
-
-
-@statistic("A dictionary of the number of recommended items per day")
-def recommended_items_per_day(object):
-    """
-    It returns a a timeseries of recommended item counts per day.
-    Each timeseries item has two fields: date and value
-    """
-    # count recommendations for each day found in entries
-    res = (
-        object.recommendations.groupby(by=object
-                                       .recommendations["timestamp"].dt.date)
-        .count()
-        .iloc[:, 0]
-    )
-
-    # create a Series with period's start and end times and value of 0
-    init = pd.Series(
-        [0, 0],
-        index=[
-            pd.to_datetime(start(object)).date(),
-            pd.to_datetime(end(object)).date(),
-        ],
-    )
-
-    # remove duplicate entries for corner cases where start and end time match
-    init.drop_duplicates(keep="first", inplace=True)
-
-    # append above two indexes and values (i.e. 0) to the Series
-    # with axis=1, same indexes are being merged
-    # since dataframe is created, get the first column
-    res = pd.concat([res, init], ignore_index=False, axis=1).iloc[:, 0]
-
-    # convert Nan values created by the concatenation to 0
-    # and change data type back to int
-    res = res.fillna(0).astype(int)
-
-    # fill the in between days with zero user_actions
-    res = res.asfreq("D", fill_value=0)
-
-    # convert datetimeindex to string
-    res.index = res.index.format()
-
-    # convert series to dataframe with extra column having the dates
-    res = res.to_frame().reset_index()
-
-    # rename columns to date, value
-    res.rename(columns={res.columns[0]: "date", res.columns[1]: "value"},
-               inplace=True)
-
-    # return a list of objects with date and value fields
-    return res.to_dict(orient="records")
-
-
-@statistic("A dictionary of the number of recommended items per month")
-def recommended_items_per_month(object):
-    """
-    It returns a a timeseries of recommended item counts per month.
-    Each timeseries item has two fields: date and value
-    """
-    # count recommendations for each day found in entries
-    res = (
-        object.recommendations.groupby(by=object
-                                       .recommendations["timestamp"].dt.date)
-        .count()
-        .iloc[:, 0]
-    )
-
-    # create a Series with period's start and end times and value of 0
-    init = pd.Series(
-        [0, 0],
-        index=[
-            pd.to_datetime(start(object)).date(),
-            pd.to_datetime(end(object)).date(),
-        ],
-    )
-
-    # remove duplicate entries for corner cases where start and end time match
-    init.drop_duplicates(keep="first", inplace=True)
-
-    # append above two indexes and values (i.e. 0) to the Series
-    # with axis=1, same indexes are being merged
-    # since dataframe is created, get the first column
-    res = pd.concat([res, init], ignore_index=False, axis=1).iloc[:, 0]
-
-    # convert Nan values created by the concatenation to 0
-    # and change data type back to int
-    res = res.fillna(0).astype(int)
-
-    # fill the in between days with zero user_actions
-    res = res.asfreq("D", fill_value=0)
-
-    # resample results in Monthly granularity
-    res = res.resample('M').sum()
-
-    # convert datetimeindex to string
-    res.index = res.index.format()
-
-    # convert series to dataframe with extra column having the dates
-    res = res.to_frame().reset_index()
-
-    # rename columns to date, value
-    res.rename(columns={res.columns[0]: "date", res.columns[1]: "value"},
-               inplace=True)
-
-    # keep YYYY-MM format in date field
-    res['date'] = res['date'].str[:-3]
-
-    # return a list of objects with date and value fields
-    return res.to_dict(orient="records")
 
 
 @statistic("A dictionary of the number of user actions per day")
@@ -1379,6 +437,405 @@ def user_actions_per_month(object):
     return res.to_dict(orient="records")
 
 
+@statistic("A dictionary of the number of recommended items per day")
+def recommended_items_per_day(object):
+    """
+    It returns a a timeseries of recommended item counts per day.
+    Each timeseries item has two fields: date and value
+    """
+    # count recommendations for each day found in entries
+    res = (
+        object.recommendations.groupby(by=object
+                                       .recommendations["timestamp"].dt.date)
+        .count()
+        .iloc[:, 0]
+    )
+
+    # create a Series with period's start and end times and value of 0
+    init = pd.Series(
+        [0, 0],
+        index=[
+            pd.to_datetime(start(object)).date(),
+            pd.to_datetime(end(object)).date(),
+        ],
+    )
+
+    # remove duplicate entries for corner cases where start and end time match
+    init.drop_duplicates(keep="first", inplace=True)
+
+    # append above two indexes and values (i.e. 0) to the Series
+    # with axis=1, same indexes are being merged
+    # since dataframe is created, get the first column
+    res = pd.concat([res, init], ignore_index=False, axis=1).iloc[:, 0]
+
+    # convert Nan values created by the concatenation to 0
+    # and change data type back to int
+    res = res.fillna(0).astype(int)
+
+    # fill the in between days with zero user_actions
+    res = res.asfreq("D", fill_value=0)
+
+    # convert datetimeindex to string
+    res.index = res.index.format()
+
+    # convert series to dataframe with extra column having the dates
+    res = res.to_frame().reset_index()
+
+    # rename columns to date, value
+    res.rename(columns={res.columns[0]: "date", res.columns[1]: "value"},
+               inplace=True)
+
+    # return a list of objects with date and value fields
+    return res.to_dict(orient="records")
+
+
+@statistic("A dictionary of the number of recommended items per month")
+def recommended_items_per_month(object):
+    """
+    It returns a a timeseries of recommended item counts per month.
+    Each timeseries item has two fields: date and value
+    """
+    # count recommendations for each day found in entries
+    res = (
+        object.recommendations.groupby(by=object
+                                       .recommendations["timestamp"].dt.date)
+        .count()
+        .iloc[:, 0]
+    )
+
+    # create a Series with period's start and end times and value of 0
+    init = pd.Series(
+        [0, 0],
+        index=[
+            pd.to_datetime(start(object)).date(),
+            pd.to_datetime(end(object)).date(),
+        ],
+    )
+
+    # remove duplicate entries for corner cases where start and end time match
+    init.drop_duplicates(keep="first", inplace=True)
+
+    # append above two indexes and values (i.e. 0) to the Series
+    # with axis=1, same indexes are being merged
+    # since dataframe is created, get the first column
+    res = pd.concat([res, init], ignore_index=False, axis=1).iloc[:, 0]
+
+    # convert Nan values created by the concatenation to 0
+    # and change data type back to int
+    res = res.fillna(0).astype(int)
+
+    # fill the in between days with zero user_actions
+    res = res.asfreq("D", fill_value=0)
+
+    # resample results in Monthly granularity
+    res = res.resample('M').sum()
+
+    # convert datetimeindex to string
+    res.index = res.index.format()
+
+    # convert series to dataframe with extra column having the dates
+    res = res.to_frame().reset_index()
+
+    # rename columns to date, value
+    res.rename(columns={res.columns[0]: "date", res.columns[1]: "value"},
+               inplace=True)
+
+    # keep YYYY-MM format in date field
+    res['date'] = res['date'].str[:-3]
+
+    # return a list of objects with date and value fields
+    return res.to_dict(orient="records")
+
+
+@metric("The percentage (%) of unique items  to the total number "
+        "of items")
+def catalog_coverage(object):
+    """
+    Calculate the percentage (%) of unique items
+    found to the total number of items
+    """
+    return round((total_unique_recommended_items(object) * 100.0 /
+                  items(object)), 2)
+
+
+@metric("The percentage (%) of unique users to the total number of users")
+def user_coverage(object):
+    """
+    Calculate the percentage (%) of unique users  to the total number of users
+    """
+    return round((total_unique_users_recommended(object) * 100.0 /
+                  users(object)), 2)
+
+
+@metric(
+    "The ratio of user hits divided by the total number of users "
+    "(user hit: a user that has accessed at least one item "
+    "that is also a personal recommendation)"
+)
+def hit_rate(object):
+    """
+    1) For each user get the recommended items and the items the user
+    accessed
+    2) Check if the user has at least one accessed item in recommendations
+    3) If yes increase number of hits by one
+    4) Divide by the total number of users
+    """
+    # object.users contains already only the registered ones
+    # a matrix of User ids and the respective accessed items' ids
+    access_df = object.users[["id", "accessed_resources"]]
+
+    # a matrix of User ids and the respective recommended items' ids
+    rec_df = (
+        object.recommendations[[object.id_field, "resource_id"]]
+        .groupby([object.id_field])
+        .agg({"resource_id": lambda x: x.unique().tolist()})
+        .reset_index()
+    )
+
+    # performs a left join on User id, which means that nan values
+    # are set for cases where no recommendations were made
+    data = pd.merge(access_df, rec_df, left_on="id", right_on=object.id_field,
+                    how="inner")
+
+    # calculate hits per user
+    # performs an interection of access and recommended items per user (row)
+    data['intersect'] = data.apply(lambda row: list(set(
+        row['accessed_resources']).intersection(row['resource_id'])), axis=1)
+    # hits = the length of the intersection
+    data['intersect_len'] = data['intersect'].apply(len)
+
+    # calculate the average value
+    total_hits = data['intersect_len'].sum()
+
+    return round(total_hits/len(object.users), 5)
+
+
+@metric(
+    "The number of user clicks through recommendations panels divided by the "
+    "total times recommendation panels were presented to users. "
+    "Takes into account all historical data of user actions"
+)
+def click_through_rate(object):
+    """
+    Get only the user actions that present a recommendation panel to the user
+    in the source page
+    Those are actions with the following source paths:
+     - /services
+     - /services/
+     - /services/c/{any category name}
+    1) Count the items in above list as they represent the times
+    recommendations panels were
+    presented to the users of the portal
+    2) Narrow the above list into a new subset by selecting only user actions
+    that originate
+    from a recommendation panel
+    3) Those are actions that have the 'recommendation' string in the
+    Action column
+    4) Count the items in the subset as they represent the times users clicked
+    through recommendations
+    5) Divide the items of the subset with the items of the first list to get
+    the click-through rate
+    """
+
+    # get user actions
+    if object.schema == 'legacy':
+        user_actions_recpanel_views = object.user_actions[
+            object.user_actions['source_path'].isin(
+                ['/services', '/services/']
+            ) |
+            object.user_actions['source_path'].str.startswith('/services/c/')
+        ]
+    else:
+        user_actions_recpanel_views = object.user_actions[
+            object.user_actions['source_path'].str.startswith('search%2F')
+        ]
+
+    user_actions_recpanel_clicks = user_actions_recpanel_views[
+        user_actions_recpanel_views['panel'] == 'recommendation_panel'
+    ]
+    try:
+        return round(
+            len(user_actions_recpanel_clicks)
+            / len(user_actions_recpanel_views), 2
+        )
+    except ZeroDivisionError:
+        return 0.00
+
+
+@metric(
+    "The diversity of the recommendations according to Shannon Entropy. "
+    "The entropy is 0 when a single item is always chosen or recommended, "
+    "and log n when n items are chosen or recommended equally often."
+)
+def diversity(object, anonymous=False):
+    """
+    Calculate Shannon Entropy. The entropy is 0 when a single item is always
+    chosen or recommended, and log n when n items are chosen or recommended
+    equally often.
+    """
+    # keep recommendations with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    if anonymous:
+        recs = object.recommendations
+    else:
+        recs = object.recommendations[
+            (object.recommendations[object.id_field]
+                .find_registered(object.schema))
+        ]
+
+    # this variable keeps the sum of user_norm (where user_norm is
+    # the count of how many times a User has been suggested)
+    # however since no cutoff at per user recommendations is applied and
+    # also since each recommendation entry is one-to-one <user id> <item id>
+    # then the total number of recommendations is equal to this sum
+
+    # remember that recommendations have been previously filtered based
+    # on the existance of users and items
+
+    # item_count
+    # group recommendations entries by item id and
+    # then count how many times each item has been suggested
+    gr_item = recs.groupby(["resource_id"]).count()
+
+    # create a dictionary of item_count in order to
+    # map the item id to the respective item_count
+    # key=<item id> and value=<item_count>
+    d_item = gr_item[object.id_field].to_dict()
+
+    # each element represent the item's recommendations occurance
+    # e.g. [1,6,7]
+    # a item was recommended 1 time, another 6 times and another 7 times
+    items = np.array(list(d_item.values()))
+
+    # the total number of recommendations
+    n_recommendations = items.sum()
+
+    # element-wise computations
+    # (division for each item's recommendations occurance)
+    recommended_probability = items / n_recommendations
+
+    # H=-Sum(p*logp) [element-wise]
+    shannon_entropy = -np.sum(
+        recommended_probability * np.log2(recommended_probability)
+    )
+
+    return round(shannon_entropy, 4)
+
+
+@metric(
+    "The diversity of the recommendations according to GiniIndex. "
+    "The index is 0 when all items are "
+    "chosen equally often, and 1 when a single item is always chosen."
+)
+def diversity_gini(object, anonymous=False):
+    """
+    Calculate GiniIndex based on
+    https://elliot.readthedocs.io/en/latest/_modules/elliot/evaluation
+    /metrics/diversity/gini_index/gini_index.html#GiniIndex
+    (see book https://link.springer.com/10.1007/978-1-4939-7131-2_110158)
+    """
+    # keep recommendations with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    if anonymous:
+        recs = object.recommendations
+    else:
+        recs = object.recommendations[
+            (object.recommendations[object.id_field]
+                .find_registered(object.schema))
+        ]
+    # this variable keeps the sum of user_norm (where user_norm is
+    # the count of how many times a User has been suggested)
+    # however since no cutoff at per user recommendations is applied and
+    # also since each recommendation entry is one-to-one <user id> <item id>
+    # then the total number of recommendations is equal to this sum
+    free_norm = len(recs.index)
+
+    # item_count
+    # group recommendations entries by item id and
+    # then count how many times each item has been suggested
+    gr_item = recs.groupby(["resource_id"]).count()
+
+    # create a dictionary of item_count in order to
+    # map the item id to the respective item_count
+    # key=<item id> and value=<item_count>
+    d_item = gr_item[object.id_field].to_dict()
+
+    # total number of recommended itemss
+    n_recommended_items = len(d_item)
+
+    # total number of items
+    num_items = items(object)
+
+    # create a zero list
+    # to calculate gini index including elements with 0 occurance
+    zeros = [0] * (num_items - n_recommended_items)
+
+    gini = sum(
+        [
+            (2 * (j + 1) - num_items - 1) * (cs / free_norm)
+            for j, cs in enumerate(zeros + sorted(d_item.values()))
+        ]
+    )
+
+    gini /= num_items - 1
+
+    return round(gini, 4)
+
+
+@metric("The novelty expresses how often new and unseen items are"
+        " recommended to users")
+def novelty(object):
+    """Calculate novelty of recommendations
+    using the n=SUM(-log(p(i)))/|R| formula"""
+    # published items
+    items_pub = object.items["id"]
+    # recommended items to authenticated users
+    items_rec = (object
+                 .recommendations[object.recommendations[object.id_field]
+                                  .find_registered(
+                                     object.schema)]["resource_id"])
+
+    # items that are published and recommended
+    items_recpub = items_rec[items_rec
+                             .isin(items_pub)].drop_duplicates()
+
+    # user actions
+    ua = object.user_actions
+    # user actions filtered if src and target the same. Also filter out
+    # if target equals -1 and filter out anonymous users
+    ua_serv_view = ua[
+        (ua["source_resource_id"] != ua["target_resource_id"])
+        & (ua["target_resource_id"] != -1)
+        & (ua["target_resource_id"] is not None)
+        & (ua[object.id_field].find_registered(object.schema))
+    ]
+
+    # count item views by item id (sorted by item id)
+    items_viewed = (ua_serv_view["target_resource_id"]
+                    .value_counts().sort_index())
+
+    # create a table for each recommended item with columns
+    # for number of views, p(i) and -log(pi)
+    r_items = pd.DataFrame(index=items_recpub).sort_index()
+    # add views column to assign views to each recommended item
+    r_items["views"] = items_viewed
+
+    # count the total item views in order to compute the portions p(i)
+    total_views = r_items["views"].sum()
+
+    # count the total recommended items |R|
+    total_items = len(r_items)
+    # compute the p(i) of each recommeneded item
+    r_items["pi"] = r_items["views"] / total_views
+    # calculate the negative log of the p(i).
+    r_items["-logpi"] = -np.log2(r_items["pi"])
+
+    # calculate novelty based on formula n=SUM(-log(p(i)))/|R|
+    novelty = r_items["-logpi"].sum() / total_items
+
+    return round(novelty, 4)
+
+
 @metric(
     "The mean value of the accuracy score found for each user defined by the "
     "fraction of the number of the correct predictions by the total number "
@@ -1456,3 +913,394 @@ def accuracy(object):
     # return the mean value of all users' accuracy score
     # up to 4 digits precision
     return round(data["resource_id"].mean(), 4)
+
+
+@metric("The Top 5 recommended items according to recommendations entries")
+def top5_items_recommended(
+    object, k=5, base="https://marketplace.eosc-portal.eu", anonymous=False
+):
+    """
+    Calculate the Top 5 recommended items according to
+    the recommendations entries.
+    Return a list of list with the elements:
+        #   (i) item id
+        #  (ii) item name
+        # (iii) item page appended with base (to create the URL)
+        #  (iv) total number of recommendations of the item
+        #   (v) percentage of the (iv) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+    Item's info is being retrieved from the external source
+    (i.e. each line forms: item_id, item_name, page_id)
+    """
+    # keep recommendations with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    if anonymous:
+        recs = object.recommendations
+    else:
+        recs = object.recommendations[
+            (object.recommendations[object.id_field]
+                .find_registered(object.schema))
+        ]
+
+    # item_count
+    # group recommendations entries by item id and
+    # then count how many times each item has been suggested
+    gr_item = recs.groupby(["resource_id"]).count()
+
+    # create a dictionary of item_count in order to
+    # map the item id to the respective item_count
+    # key=<item id> and value=<item_count>
+    d_item = gr_item[object.id_field].to_dict()
+
+    # convert dictionary to double list (list of lists)
+    # where the sublist is <item_id> <item_count>
+    # and sort them from max to min <item_count>
+    l_item = list(map(lambda x: [x, d_item[x]], d_item))
+    l_item.sort(key=lambda x: x[1], reverse=True)
+
+    # get only the first k elements
+    l_item = l_item[:k]
+
+    topk_items = []
+
+    for item in l_item:
+        # get item's info from dataframe
+        _df_item = (object
+                    .items[(object
+                            .items["id"]
+                            .isin([item[0]]))])
+
+        # append a list with the elements:
+        #   (i) item id
+        #  (ii) item name
+        # (iii) item page appended with base (to create the URL)
+        #  (iv) total number of recommendations of the item
+        #   (v) percentage of the (iv) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+        topk_items.append(
+            {
+                "item_id": item[0],
+                "item_name": str(_df_item["name"].item()),
+                "item_url": base + str(_df_item["path"].item()),
+                "recommendations": {
+                    "value": item[1],
+                    "percentage": round(100 * item[1] / len(recs.index), 2),
+                    "of_total": len(recs.index),
+                },
+            }
+        )
+
+    return topk_items
+
+
+@metric("The Top 5 ordered items according to user actions entries")
+def top5_items_ordered(
+    object, k=5, base="https://marketplace.eosc-portal.eu", anonymous=False
+):
+    """
+    Calculate the Top 5 ordered items according to user actions entries.
+    User actions with Target Pages that lead to unknown items (=-1)
+    are being ignored.
+    Return a list of list with the elements:
+        #   (i) item id
+        #  (ii) item name
+        # (iii) item page appended with base (to create the URL)
+        #  (iv) total number of orders of the item
+        #   (v) percentage of the (iv) to the total number of orders
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+    """
+    # keep user actions with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    # user_actions with Target Pages that lead to unknown items (=-1)
+    # are being ignored
+    if anonymous:
+        uas = object.user_actions[
+            (object.user_actions["reward"] == 1.0)
+            & (object.user_actions["target_resource_id"] != -1)
+            & (object.user_actions["target_resource_id"] is not None)
+            & (object.user_actions[object.id_field]
+                .find_registered(object.schema))
+        ]
+    else:
+        uas = object.user_actions[
+            (object.user_actions["reward"] == 1.0)
+            & (object.user_actions["target_resource_id"] != -1)
+            & (object.user_actions["target_resource_id"] is not None)
+        ]
+
+    # item_count
+    # group user_actions entries by item id and
+    # then count how many times each item has been suggested
+    gr_item = uas.groupby(["target_resource_id"]).count()
+
+    # create a dictionary of item_count in order to
+    # map the item id to the respective item_count
+    # key=<item id> and value=<item_count>
+    d_item = gr_item[object.id_field].to_dict()
+
+    # convert dictionary to double list (list of lists)
+    # where the sublist is <item_id> <item_count>
+    # and sort them from max to min <item_count>
+    l_item = list(map(lambda x: [x, d_item[x]], d_item))
+    l_item.sort(key=lambda x: x[1], reverse=True)
+
+    # get only the first k elements
+    l_item = l_item[:k]
+
+    topk_items = []
+
+    for item in l_item:
+        # get items's info from dataframe
+        _df_item = object.items[object.items["id"].isin([item[0]])]
+        # append a list with the elements:
+        #   (i) item id
+        #  (ii) item name
+        # (iii) item page appended with base (to create the URL)
+        #  (iv) total number of orders of the item
+        #   (v) percentage of the (iv) to the total number of orders
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+        topk_items.append(
+            {
+                "item_id": item[0],
+                "item_name": str(_df_item["name"].item()),
+                "item_url": base + str(_df_item["path"].item()),
+                "orders": {
+                    "value": item[1],
+                    "percentage": round(100 * item[1] / len(uas.index), 2),
+                    "of_total": len(uas.index),
+                },
+            }
+        )
+
+    return topk_items
+
+
+def __top5_recommended(object, k=5, element='category', anonymous=False):
+    """
+    Calculate the Top 5 recommended elements according to
+    the recommendations entries.
+    Return a list of list with the elements:
+        #  (i) element id
+        #  (ii) element name (according to element collection)
+        #  (iii) total number of recommendations of the element
+        #  (iv) percentage of the (iii) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+    Element's info is being retrieved from the marketplace_rs MongoDB source
+    """
+    # keep recommendations with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    if anonymous:
+        recs = object.recommendations
+    else:
+        recs = object.recommendations[
+            (object.recommendations[object.id_field]
+                .find_registered(object.schema))
+        ]
+
+    # rename the column at a copy (not in place) for more readable processing
+    _items = object.items.rename(columns={'id': 'resource_id'})
+
+    # create an inner join between the recommendations collection
+    # and the items collection
+    # since a element is a list of element ids
+    # the rows are further expanded (exploded) into rows per element id
+    # inner join means that elements must exist in both items collection
+    # and recommendations collection
+    merged = recs.merge(_items, on='resource_id')
+    exp = merged.explode(element)
+
+    # count the total orders where the associated items have elements
+    total = len(merged.dropna(subset=[element]))
+
+    # count elements' ids and covert pandas series to dataframe
+    # user_id holds the same values with all other columns
+    # it is just the first column
+    cat = exp.groupby([element])[object.id_field].count().to_frame()
+
+    # reset indexes and rename columns accordingly
+    cat = cat.reset_index().rename(columns={element: 'id',
+                                            object.id_field: 'count'})
+
+    if object.schema == 'legacy':
+        # create a second inner join with the elements
+        # in order to retrieve the name of the elements
+        # inner join means that element must exist in both elements collection
+        # and cat collection
+        if element == 'category':
+            _input = object.categories
+        else:
+            _input = object.scientific_domains
+
+        full_cat = cat.merge(_input, on='id')
+
+    else:
+        full_cat = cat.rename(columns={'id': 'name'})
+        # work only on the upper class
+        full_cat = full_cat[~full_cat['name'].str.contains(">")]
+
+    # sort based on count
+    # get top k
+    # and convert it to a list of dictionaries
+    # where each dictionary equals to the df's record,
+    # and each column of the df is the key of the dictionary
+    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
+                                orient='records')
+
+    # create similar format to other kpis
+    topk_elements = []
+
+    for entry in topk:
+        # append a list with the elements:
+        #  (i) element id
+        #  (ii) element name (retrieved from element collection)
+        #  (iii) total number of recommendations of the item
+        #  (iv) percentage of the (iii) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+        topk_elements.append(
+            {
+                element+"_name": entry['name'],
+                "recommendations": {
+                    "value": entry['count'],
+                    "percentage": round(100 * entry['count'] / total, 2),
+                    "of_total": total,
+                },
+            }
+        )
+
+    return topk_elements
+
+
+def __top5_ordered(object, element='category', k=5, anonymous=False):
+    """
+    Calculate the Top 5 ordered elements according to user actions entries.
+    Return a list of list with the elements:
+        #  (i) element id
+        #  (ii) element name (according to element collection)
+        #  (iii) total number of orders of the element
+        #  (iv) percentage of the (iii) to the total number of orders
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+    Element's info is being retrieved from the marketplace_rs MongoDB source
+    """
+    # keep user actions with or without anonymous suggestions
+    # based on anonymous flag (default=False, i.e. ignore anonymous)
+    # user_actions with Target Pages that lead to unknown items (=-1)
+    # are being ignored
+    if anonymous:
+        uas = object.user_actions[
+            (object.user_actions["reward"] == 1.0)
+            & (object.user_actions["target_resource_id"] != -1)
+            & (object.user_actions[object.id_field]
+                .find_registered(object.schema))
+        ]
+    else:
+        uas = object.user_actions[
+            (object.user_actions["reward"] == 1.0)
+            & (object.user_actions["target_resource_id"] != -1)
+        ]
+
+    # rename the column at a copy (not in place) for more readable processing
+    _items = object.items.rename(columns={'id': 'target_resource_id'})
+
+    # create an inner join between the recommendations collection
+    # and the items collection
+    # since a element is a list of element ids
+    # the rows are further expanded (exploded) into rows per element id
+    # inner join means that elements must exist in both items collection
+    # and recommendations collection
+    merged = uas.merge(_items, on='target_resource_id')
+    exp = merged.explode(element)
+
+    # count the total orders where the associated items have elements
+    total = len(merged.dropna(subset=[element]))
+
+    # count elements' ids and covert pandas series to dataframe
+    # user_id holds the same values with all other columns
+    # it is just the first column
+    cat = exp.groupby([element])[object.id_field].count().to_frame()
+
+    # reset indexes and rename columns accordingly
+    cat = cat.reset_index().rename(columns={element: 'id',
+                                            object.id_field: 'count'})
+
+    if object.schema == 'legacy':
+        # create a second inner join with the elements
+        # in order to retrieve the name of the elements
+        # inner join means that element must exist in both elements collection
+        # and cat collection
+        if element == 'category':
+            _input = object.categories
+        else:
+            _input = object.scientific_domains
+
+        full_cat = cat.merge(_input, on='id')
+
+    else:
+        full_cat = cat.rename(columns={'id': 'name'})
+        # work only on the upper class
+        full_cat = full_cat[~full_cat['name'].str.contains(">")]
+
+    # sort based on count
+    # get top k
+    # and convert it to a list of dictionaries
+    # where each dictionary equals to the df's record,
+    # and each column of the df is the key of the dictionary
+    topk = full_cat.sort_values('count', ascending=False).head(k).to_dict(
+                                orient='records')
+
+    # create similar format to other kpis
+    topk_elements = []
+
+    for entry in topk:
+
+        # append a list with the elements:
+        #  (i) element id
+        #  (ii) element name (retrieved from element collection)
+        #  (iii) total number of recommendations of the item
+        #  (iv) percentage of the (iii) to the total number of recommendations
+        #       expressed in %, with or without anonymous,
+        #       based on the function's flag
+        topk_elements.append(
+            {
+                element+"_name": entry['name'],
+                "orders": {
+                    "value": entry['count'],
+                    "percentage": round(100 * entry['count'] / total, 2),
+                    "of_total": total,
+                },
+            }
+        )
+
+    return topk_elements
+
+
+@metric("The Top 5 recommended categories according to recommendations entries"
+        )
+def top5_categories_recommended(object, k=5, anonymous=False):
+    return __top5_recommended(object, k=5, element='category', anonymous=False)
+
+
+@metric("The Top 5 recommended scientific domains according to recommendations\
+entries")
+def top5_scientific_domains_recommended(object, k=5, anonymous=False):
+    return __top5_recommended(object, k=5, element='scientific_domain',
+                              anonymous=False)
+
+
+@metric("The Top 5 ordered categories according to recommendations entries"
+        )
+def top5_categories_ordered(object, k=5, anonymous=False):
+    return __top5_ordered(object, k=5, element='category', anonymous=False)
+
+
+@metric("The Top 5 ordered scientific domains according to recommendations\
+entries")
+def top5_scientific_domains_ordered(object, k=5, anonymous=False):
+    return __top5_ordered(object, k=5, element='scientific_domain',
+                          anonymous=False)

--- a/rs-stream.py
+++ b/rs-stream.py
@@ -272,7 +272,7 @@ def main(args):
                 "resource_ids": message["recommendations"],
                 "type": rec_map[message["panel_id"]],
                 "ingestion": "stream",
-                "provider": message["recommender_systems"][0],
+                "provider": message["recommender_systems"][0].lower(),
             }
 
             rsmetrics_db["recommendations"].insert_one(record)


### PR DESCRIPTION
- [x] The `rs-rstream.py` complies with the lowercase conversion of the provider names (engines).
- [x]  The `rsmetrics.py` calculates metrics per provider/engine (not per category).
- [x] It keeps both `current` and `legacy` modes for all calculations.
- [x] The `source_path_id` and the `target_path_id` of not known cases are now `None` but it supports `-1` values also (backward compatible).
- [x] Code in `metrics.py` has been re-arranged. First `statistics` are defined and then `metrics`.
- [x] `Hit-Rate` function was re-implemented because it was buggy.
- [x] `Click-Through-Rate` function now supports both `current` and `legacy` modes.
- [x] Code reduced in defining `Top_5_recommended_categories` and  `Top_5_recommended_scientific_domains`. Respectively for Top `orders` too. 
- [x] `Top5` metrics are calculated where applicable.
- [x] `Top5` elements (i.e. category, sc. domains) are now in order. Specifically, they produce the upper class (more general) element. 