### PR TITLE
REC-258 Support metrics calculations for anonymous users

### DIFF
--- a/metric_descriptions/click-through-rate.yml
+++ b/metric_descriptions/click-through-rate.yml
@@ -8,7 +8,7 @@ description: >
 output:
     type: float
     min: 0
-    max: +inf
+    max: +\(\infty\)
     comment: A value of 0 indicates that no clicks through recommendations panels occurred
 
 prerequisites:

--- a/metric_descriptions/hit-rate.yml
+++ b/metric_descriptions/hit-rate.yml
@@ -9,7 +9,7 @@ description: >
 output:
     type: float
     min: 0
-    max: +inf
+    max: +\(\infty\)
     comment: A value of 0 indicates that no user hits occurred
 
 prerequisites:

--- a/preprocessor_common.py
+++ b/preprocessor_common.py
@@ -209,9 +209,11 @@ for col in ['scientific_domain', 'category']:
     )
 
     rsmetrics_db[col].drop()
-    rsmetrics_db[col].insert_many(data)
-
-    logging.info("{} collection stored...".format(col))
+    try:
+        rsmetrics_db[col].insert_many(data)
+        logging.info("{} collection stored...".format(col))
+    except Exception:
+        pass
 
 # B. Working on resources
 

--- a/webservice/app.py
+++ b/webservice/app.py
@@ -132,7 +132,8 @@ def html_metrics(report_name):
 
     result = {}
     stats_needed = [
-        "users",
+        "registered_users",
+        "anonymous_users",
         "recommended_items",
         "items",
         "user_actions",
@@ -140,11 +141,11 @@ def html_metrics(report_name):
         "user_actions_registered_perc",
         "user_actions_anonymous",
         "user_actions_anonymous_perc",
-        "user_actions_order",
-        "user_actions_order_registered",
-        "user_actions_order_registered_perc",
-        "user_actions_order_anonymous",
-        "user_actions_order_anonymous_perc",
+        "item_views",
+        "item_views_registered",
+        "item_views_registered_perc",
+        "item_views_anonymous",
+        "item_views_anonymous_perc",
         "start",
         "end",
     ]

--- a/webservice/templates/rsmetrics.html
+++ b/webservice/templates/rsmetrics.html
@@ -225,11 +225,27 @@
                                             <div class="widget-content-outer">
                                                 <div class="widget-content-wrapper">
                                                     <div class="widget-content-left">
-                                                        <div class="widget-heading">Users</div>
-                                                        <div class="widget-subheading">{{data.users.doc}}</div>
+                                                        <div class="widget-heading">Registered Users</div>
+                                                        <div class="widget-subheading">{{data.registered_users.doc}}</div>
                                                     </div>
                                                     <div class="widget-content-right">
-                                                        <div class="widget-numbers text-success">{{data.users.value}}
+                                                        <div class="widget-numbers text-primary">{{data.registered_users.value}}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </li>
+                                   <li class="list-group-item">
+                                        <div class="widget-content p-0">
+                                            <div class="widget-content-outer">
+                                                <div class="widget-content-wrapper">
+                                                    <div class="widget-content-left">
+                                                        <div class="widget-heading">Anonymous Users</div>
+                                                        <div class="widget-subheading">{{data.anonymous_users.doc}}</div>
+                                                    </div>
+                                                    <div class="widget-content-right">
+                                                        <div class="widget-numbers text-warning">{{data.anonymous_users.value}}
                                                         </div>
                                                     </div>
                                                 </div>
@@ -245,7 +261,7 @@
                                                         <div class="widget-subheading">{{data['items'].doc}}</div>
                                                     </div>
                                                     <div class="widget-content-right">
-                                                        <div class="widget-numbers text-primary">{{data['items'].value}}
+                                                        <div class="widget-numbers text-success">{{data['items'].value}}
                                                         </div>
                                                     </div>
                                                 </div>
@@ -262,7 +278,7 @@
                                                         </div>
                                                     </div>
                                                     <div class="widget-content-right">
-                                                        <div class="widget-numbers text-warning">
+                                                        <div class="widget-numbers text-success">
                                                             {{data.recommended_items.value}}</div>
                                                     </div>
                                                 </div>
@@ -316,7 +332,7 @@
                                             <div class="widget-content-outer">
                                                 <div class="widget-content-wrapper">
                                                     <div class="widget-content-left">
-                                                        <div class="widget-heading">by anonymous Users</div>
+                                                        <div class="widget-heading">by Anonymous Users</div>
                                                     </div>
                                                     <div class="widget-content-right">
                                                         <div class="widget-numbers sm text-warning">
@@ -341,13 +357,13 @@
                                                 <div class="widget-content-wrapper">
                                                     <div class="widget-content-left">
                                                         <div class="font-icon-wrapper font-icon-lg">
-                                                            <i class="pe-7s-cash icon-gradient bg-grow-early"> </i>
+                                                            <i class="pe-7s-look icon-gradient bg-malibu-beach"> </i>
                                                         </div>
                                                     </div>
                                                     <div class="widget-content-left">
-                                                        <div class="widget-heading">Total Orders
+                                                        <div class="widget-heading">Items Viewed
                                                             <span
-                                                                class="widget-numbers text-success">{{data.user_actions_order.value}}</span>
+                                                                class="widget-numbers text-success">{{data.item_views.value}}</span>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -363,15 +379,33 @@
                                                     </div>
                                                     <div class="widget-content-right">
                                                         <div class="widget-numbers text-primary">
-                                                            {{data.user_actions_order_registered.value}}</div>
+                                                            {{data.item_views_registered.value}}</div>
                                                     </div>
                                                 </div>
                                                 <div class="widget-subheading widget-content-right text-primary">
-                                                    ({{data.user_actions_order_registered_perc.value}}%)</div>
+                                                    ({{data.item_views_registered_perc.value}}%)</div>
                                             </div>
                                         </div>
                                     </li>
-                                    
+                                     <li class="list-group-item">
+                                        <div class="widget-content p-0">
+                                            <div class="widget-content-outer">
+                                                <div class="widget-content-wrapper">
+                                                    <div class="widget-content-left">
+                                                        <div class="widget-heading">by Anonymous Users</div>
+                                                    </div>
+                                                    <div class="widget-content-right">
+                                                        <div class="widget-numbers sm text-warning">
+                                                            {{data.item_views_anonymous.value}}</div>
+                                                    </div>
+                                                </div>
+                                                <div class="widget-subheading widget-content-right text-warning">
+                                                    ({{data.item_views_anonymous_perc.value}})</div>
+
+                                            </div>
+                                        </div>
+                                    </li>
+
                                 </ul>
                             </div>
                         </div>


### PR DESCRIPTION
This PR introduces:
1.  New statistics for registered and anonymous users. 
2. The metrics calculations, the KPIs and the graphs now support both registered and anonymous users.

In detail:
* The internal field of aai_uid of the Pandas dataframe of both the user actions and the recommendations now keeps the aai_uid value of the registered users or the unique_id value of the anonymous users. Additionally, an extra column of user actions and recommendations determining registered or anonymous users (True/False) has been added to the Pandas dataframe of both the user actions and the recommendations.
* Items are now read in string format.
* Users are being created from the user actions for both registered and anonymous users.
* The statistics "registered_users", "anonymous_users", "item_views" (and the respective sub views of registered and anonymous with their percentage).
* The statistics "user_actions_panel" and "user_actions_order", (and the respective sub views of registered and anonymous with their percentage) have been removed, because they are unused.
* Respective changes to UI in order to support the new statistics.
* Minor visual fixes in metrics descriptions.
* Fix in preprocessor_common.py not to crash in case of no scientific domain and category collections.
The code does not preserve backward compatibility with the legacy mode anymore.