### PR TITLE
REC-262 Add support for legacy mode and preserve list as an output of top5 KPIs

### DIFF
--- a/metric_descriptions/hit-rate.yml
+++ b/metric_descriptions/hit-rate.yml
@@ -29,5 +29,5 @@ process:
 
 # This is optional for visual stylization of the metric when displayed on the report
 style:
-    icon: pe-7s-look
-    color: bg-malibu-beach
+    icon: pe-7s-star
+    color: bg-mean-fruit

--- a/webservice/templates/kpis.html
+++ b/webservice/templates/kpis.html
@@ -245,7 +245,7 @@
                             <div class="card mb-3 widget-content">
                                 <div class="widget-content-wrapper">
                                     <div class="font-icon-wrapper font-icon-lg">
-                                        <i class="pe-7s-look icon-gradient bg-malibu-beach"> </i>
+                                        <i class="pe-7s-star icon-gradient bg-mean-fruit"> </i>
                                     </div>
                                     <div class="widget-content-left">
 

--- a/webservice/templates/rsmetrics.html
+++ b/webservice/templates/rsmetrics.html
@@ -340,7 +340,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="widget-subheading widget-content-right text-warning">
-                                                    ({{data.user_actions_anonymous_perc.value}})</div>
+                                                    ({{data.user_actions_anonymous_perc.value}}%)</div>
 
                                             </div>
                                         </div>
@@ -400,7 +400,7 @@
                                                     </div>
                                                 </div>
                                                 <div class="widget-subheading widget-content-right text-warning">
-                                                    ({{data.item_views_anonymous_perc.value}})</div>
+                                                    ({{data.item_views_anonymous_perc.value}}%)</div>
 
                                             </div>
                                         </div>


### PR DESCRIPTION
This PR:
- Adds backward compatibility to legacy mode. Metrics are now calculated with registered and anonymous users on new UI format. Again, same logic as in current mode. Set 0 to the internal Dataframe field user_id when anonymous, otherwise the value of user_id as it is MongoDB (for registered users).
- Top5 KPIs now always return a list (even empty), so UI does not break.
- Minor changes in icon and color of Hit Rate, because the same was used for the new statistic Item Views, before.
- Minor typo with missing % for anonymous percentage in UI