### PR TITLE
REC-257 Ability to fetch resources before calculations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,5 +22,6 @@ service:
     # this has an effect in exporting when from is set to 'source' 
     # and also in metrics calculations where service is considered
     published: true
-
-
+    category:
+       marketplace_rs: [service]
+       online_engine: [training, data_source]


### PR DESCRIPTION
This PR adds the ability to retrieve resources just before calculations.

- Recommender Engine of the category and the category must be specified in configuration (`config.yaml`).
- The option of `--use-cache` can be passed in order to pass the resources retrieval and perform only the calculations.