### PR TITLE
REC-264 Convert top5 ordered to top5 viewed, fix in item views and novelty

### DIFF
--- a/webservice/app.py
+++ b/webservice/app.py
@@ -196,11 +196,11 @@ def html_kpis(report_name):
     metrics_needed = [
         "hit_rate",
         "click_through_rate",
-        "top5_items_ordered",
+        "top5_items_viewed",
         "top5_items_recommended",
-        "top5_categories_ordered",
+        "top5_categories_viewed",
         "top5_categories_recommended",
-        "top5_scientific_domains_ordered",
+        "top5_scientific_domains_viewed",
         "top5_scientific_domains_recommended",
     ]
     for metric_name in metrics_needed:

--- a/webservice/templates/kpis.html
+++ b/webservice/templates/kpis.html
@@ -348,12 +348,12 @@
                         <div class="col-md-6">
                             <div class="main-card mb-3 card">
                                 <div class="card-body">
-                                    <h5 class="card-title">Top 5 ordered items</h5>
+                                    <h5 class="card-title">Top 5 viewed items</h5>
                                     <p>
-                                        {% if data.top5_items_ordered.value == None %}
+                                        {% if data.top5_items_viewed.value == None %}
                                             <span class="error">⚠️ Calculation Issue</span>
                                         {% else %}    
-                                        {% for item in data.top5_items_ordered.value %}
+                                        {% for item in data.top5_items_viewed.value %}
                                     <div class="card-shadow-info mb-3 widget-chart widget-chart2 text-start card">
                                         <div class="row">
                                             <div class="widget-content col-md-10">
@@ -372,7 +372,7 @@
                                                                     style="width: {{item.orders.percentage}}%;"></div>
                                                                 <h6
                                                                     class="justify-content-center d-flex position-absolute w-100">
-                                                                    Ordered&nbsp;<b>{{item.orders.value}}</b>&nbsp;times
+                                                                    viewed&nbsp;<b>{{item.orders.value}}</b>&nbsp;times
                                                                     out of {{item.orders.of_total}}
                                                                 </h6>
                                                             </div>
@@ -468,12 +468,12 @@
                         <div class="col-md-6">
                             <div class="main-card mb-3 card">
                                 <div class="card-body">
-                                    <h5 class="card-title">Top 5 ordered categories</h5>
+                                    <h5 class="card-title">Top 5 viewed categories</h5>
                                     <p>
-                                        {% if data.top5_categories_ordered.value == None %}
+                                        {% if data.top5_categories_viewed.value == None %}
                                         <span class="error">⚠️ Calculation Issue</span>
                                         {% else %}    
-                                        {% for item in data.top5_categories_ordered.value %}
+                                        {% for item in data.top5_categories_viewed.value %}
                                     <div class="card-shadow-info mb-3 widget-chart widget-chart2 text-start card">
                                         <div class="row">
                                             <div class="widget-content col-md-10">
@@ -492,7 +492,7 @@
                                                                     style="width: {{item.orders.percentage}}%;"></div>
                                                                 <h6
                                                                     class="justify-content-center d-flex position-absolute w-100">
-                                                                    Ordered&nbsp;<b>{{item.orders.value}}</b>&nbsp;times
+                                                                    viewed&nbsp;<b>{{item.orders.value}}</b>&nbsp;times
                                                                     out of {{item.orders.of_total}}
                                                                 </h6>
                                                             </div>
@@ -588,12 +588,12 @@
                         <div class="col-md-6">
                             <div class="main-card mb-3 card">
                                 <div class="card-body">
-                                    <h5 class="card-title">Top 5 ordered scientific domains</h5>
+                                    <h5 class="card-title">Top 5 viewed scientific domains</h5>
                                     <p>
-                                        {% if data.top5_scientific_domains_ordered.value == None %}
+                                        {% if data.top5_scientific_domains_viewed.value == None %}
                                         <span class="error">⚠️ Calculation Issue</span>
                                         {% else %}    
-                                        {% for item in data.top5_scientific_domains_ordered.value %}
+                                        {% for item in data.top5_scientific_domains_viewed.value %}
                                     <div class="card-shadow-info mb-3 widget-chart widget-chart2 text-start card">
                                         <div class="row">
                                             <div class="widget-content col-md-10">
@@ -612,7 +612,7 @@
                                                                     style="width: {{item.orders.percentage}}%;"></div>
                                                                 <h6
                                                                     class="justify-content-center d-flex position-absolute w-100">
-                                                                    Ordered&nbsp;<b>{{item.orders.value}}</b>&nbsp;times
+                                                                    viewed&nbsp;<b>{{item.orders.value}}</b>&nbsp;times
                                                                     out of {{item.orders.of_total}}
                                                                 </h6>
                                                             </div>


### PR DESCRIPTION
This PR:

- swap Top5 ordered results to Top5 viewed, where Top5 KPIs indicate results for both registered and anonymous users now
- fix class type (i.e. string) issue in item views statistic and novelty metric
- swap `find_pandas_all` to `find` regular function call, cause of a bug in reading different class types (i.e. string, integers) simultaneously from MongoDB 