### PR TITLE
REC-263 Add timestamp to resources and add tag in metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ A framework for generating statistics, metrics, KPIs, and graphs for Recommender
 ./rsmetrics.py -p athena # same procedure as the first one for 'athena' provider
 ```
 
+10. A typical `rsmetrics.py` command for a monthly report, would be:
+```bash
+./rsmetrics.py -p provider -s $(date +"%Y-%m-01") -e $(date +"%Y-%m-%d") -t "$(date +"%B %Y")"
+```
+
 ### Usage of the Streaming System
-10. Run from terminal `./rs-stream.py` in order to listen to the stream for new data, process them, and store them in the `Datastore`, concerning that particular provider:
+11. Run from terminal `./rs-stream.py` in order to listen to the stream for new data, process them, and store them in the `Datastore`, concerning that particular provider:
 ```bash
 ./rs-stream.py -a username:password -q host:port -t user_actions -d ""mongodb://localhost:27017/datastore"" -p provider_name
 ```


### PR DESCRIPTION
Concerning the `get_catalog.py`:
1. A `timestamp` field is added that takes a date-time value generated at the UTC time the script ran.
2. By default, the get_catalog does not remove old entries at the resources collection.

Concerning the `rsmetrics.py`:
1. A new argument is added under the name `tag`.
2. Results are now stored with the `name` of the given `tag` (and the old ones deleted).
3. All the latest unique resources/items at the date-time range of the given start/end time are retrieved for further processing.

A typical `rsmetrics.py` command for a monthly report, would be:
```bash
./rsmetrics.py -p provider -s $(date +"%Y-%m-01") -e $(date +"%Y-%m-%d") -t "$(date +"%B %Y")"
```
