### PR TITLE
REC-292 Add e-mail support for the RS Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,10 @@ A typical example that counts the documents found in `user_actions`, `recommenda
 ```bash
 ./monitor.py -d "mongodb://localhost:27017/rsmetrics" -s "$(date -u -d '1 day ago' '+%Y-%m-%d')" -e "$(date -u '+%Y-%m-%d')"
 ```
+
+E-mail send over SMTP for the above example:
+```bash
+./monitor.py -d "mongodb://localhost:27017/rsmetrics" -s "$(date -u -d '1 day ago' '+%Y-%m-%d')" -e "$(date -u '+%Y-%m-%d')" --email "smtp://server:port" sender@domain recipient1@domain recipient2@domain
+
+```
+

--- a/monitor.py
+++ b/monitor.py
@@ -4,6 +4,10 @@ import argparse
 import pymongo
 import logging
 from datetime import datetime
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from urllib.parse import urlparse
 
 # establish basic logging
 logging.basicConfig(
@@ -13,7 +17,41 @@ logging.basicConfig(
 )
 
 
+class Logger:
+    def __init__(self):
+        self.text = ""
+
+    def info(self, message):
+        logging.info(message)
+        self.text += message + "\n"
+
+    def error(self, message):
+        logging.error(message)
+        self.text += message + "\n"
+
+
+def send_email(sender_email, recipients, subject, body, smtp_info):
+    message = MIMEMultipart()
+    message["From"] = sender_email
+    message["To"] = ', '.join(recipients)
+    message["Subject"] = subject
+    message.attach(MIMEText(body, "plain"))
+
+    with smtplib.SMTP(smtp_info['hostname'], smtp_info['port']) as server:
+        server.starttls()
+
+        if smtp_info['username'] and smtp_info['password']:
+            server.login(smtp_info['username'], smtp_info['password'])
+
+        server.sendmail(sender_email, recipients, message.as_string())
+
+    print("Email sent successfully.")
+
+
 def main(args):
+
+    # create the logger
+    logger = Logger()
 
     try:
         # connect to the datastore
@@ -23,10 +61,10 @@ def main(args):
 
         # check if datastore is alive
         if mongo.rsmetrics_db.command('ping') == {u'ok': 1.0}:
-            logging.info("Connected succesfully to {}".format(args.datastore))
+            logger.info("Connected succesfully to {}".format(args.datastore))
 
     except Exception as e:
-        logging.error("Cannot connect to {}: {}".format(args.datastore, e))
+        logger.error("Cannot connect to {}: {}".format(args.datastore, e))
         return
 
     time_filter = {}
@@ -39,25 +77,25 @@ def main(args):
 
     if args.endtime:
         edt = datetime.fromisoformat(args.endtime)
-        args.endtime = datetime.combine(edt, datetime.max.time())
+        args.endtime = datetime.combine(edt, datetime.min.time())
         if "timestamp" not in time_filter:
             time_filter["timestamp"] = {}
-            time_filter["timestamp"]["$lte"] = args.endtime
+            time_filter["timestamp"]["$lt"] = args.endtime
 
     if args.starttime and args.endtime:
         if args.endtime < args.starttime:
-            logging.error("End date must be older than start date")
+            logger.error("End date must be older than start date")
             return
 
-    logging.info("Searching for the period {} - {}".format(args.starttime,
-                                                           args.endtime))
+    logger.info("Searching for the period {} - {}".format(args.starttime,
+                                                          args.endtime))
 
     for col in args.collection:
         try:
             doc_count = rsmetrics_db[col].count_documents(time_filter)
 
-            logging.info("> Collection '{}' has {} entries".format(col,
-                                                                   doc_count))
+            logger.info("> Collection '{}' has {} entries".format(col,
+                                                                  doc_count))
 
             for item_type in rsmetrics_db[col].distinct('type', time_filter):
                 if col != 'resources':
@@ -70,12 +108,41 @@ def main(args):
                                                                "type":
                                                                item_type}))
 
-                logging.info("\t* '{}'\thas {} entries".format(item_type,
-                                                               count))
+                logger.info("\t* '{}'\thas {} entries".format(item_type,
+                                                              count))
 
         except Exception as e:
-            logging.error("Cannot retrieve entries from collection '{}'\n{}"
-                          .format(col, e))
+            logger.error("Cannot retrieve entries from collection '{}'\n{}"
+                         .format(col, e))
+
+    if args.email:
+        smtp_info = parse_smtp_uri(args.smtp_uri)
+        send_email(args.sender_email, args.recipients,
+                   'RSeval Report from {} to {}'.format(args.starttime
+                                                        .strftime("%Y-%m-%d"),
+                                                        args.endtime
+                                                        .strftime("%Y-%m-%d")),
+                   logger.text, smtp_info)
+
+
+def parse_smtp_uri(smtp_uri):
+    parsed_uri = urlparse(smtp_uri)
+
+    if parsed_uri.scheme != 'smtp':
+        raise ValueError('Invalid SMTP URI. Scheme must be "smtp".')
+
+    username, password = None, None
+    if parsed_uri.username:
+        username = parsed_uri.username
+        if parsed_uri.password:
+            password = parsed_uri.password
+
+    return {
+        'hostname': parsed_uri.hostname,
+        'port': parsed_uri.port,
+        'username': username,
+        'password': password
+    }
 
 
 if __name__ == "__main__":
@@ -117,6 +184,21 @@ if __name__ == "__main__":
         nargs="?",
         default=None,
     )
+
+    # Add optional argument to enable email-related arguments
+    parser.add_argument('--email', action='store_true',
+                        help='Send email using SMTP URI')
+
+    # Create a mutually exclusive group for email-related arguments
+    email_group = parser.add_argument_group('Email Options')
+
+    # Add email-related arguments to the group
+    email_group.add_argument('smtp_uri', nargs='?',
+                             help='SMTP URI for the mail server')
+    email_group.add_argument('sender_email', nargs='?',
+                             help='Sender email address')
+    email_group.add_argument('recipients', nargs='*',
+                             help='Recipient email addresses (at least one)')
 
     # Pass the arguments to main method
     sys.exit(main(parser.parse_args()))


### PR DESCRIPTION
New feature:

E-mail send over SMTP for the above example:
```bash
./monitor.py -d "mongodb://localhost:27017/rsmetrics" -s "$(date -u -d '1 day ago' '+%Y-%m-%d')" -e "$(date -u '+%Y-%m-%d')" --email "smtp://server:port" sender@domain recipient1@domain recipient2@domain
```