### PR TITLE
REC-297 Add support to ignore timestamp when necessary

### DIFF
--- a/rsmetrics.py
+++ b/rsmetrics.py
@@ -121,6 +121,13 @@ optional.add_argument(
 )
 
 optional.add_argument(
+    "--ignore-timestamp",
+    help=("Enable to perform calculations without checking if items are \
+within the requested datetime range"),
+    action="store_true",
+)
+
+optional.add_argument(
     "-h", "--help", action="help", help="show this help message and exit"
 )
 optional.add_argument(
@@ -349,17 +356,22 @@ else:
 
 logging.info("Reading items...")
 run.items = pd.DataFrame(
-    list(rsmetrics_db["resources"].find({
-        "$and": [
-            {"provider": args.provider},
-            {"$or": [{"created_on": {"$lte": args.endtime}},
-                     {"created_on": None}]},
-            {"$or": [{"deleted_on": {"$gte": args.starttime}},
-                     {"deleted_on": None}]},
-            {"timestamp": {"$lte": args.endtime}} if args.endtime else {},
-            {"timestamp": {"$gte": args.starttime}} if args.starttime else {},
-        ]},
-        {"_id": 0}))
+    list(rsmetrics_db["resources"].find(
+        {
+            "$and": [
+                {"provider": args.provider},
+                {"$or": [{"created_on": {"$lte": args.endtime}},
+                         {"created_on": None}]},
+                {"$or": [{"deleted_on": {"$gte": args.starttime}},
+                         {"deleted_on": None}]},
+                {"timestamp": {"$lte": args.endtime}}
+                if (args.endtime and not args.ignore_timestamp) else {},
+                {"timestamp": {"$gte": args.starttime}}
+                if (args.starttime and not args.ignore_timestamp) else {},
+            ]
+        },
+        {"_id": 0}
+    ))
 )
 
 # from duplicates keep the latest entry


### PR DESCRIPTION
For large dataset we use `--use-cache` parameter which does not retrieve resources on-the-fly from the EOSC Marketplace. Instead it uses the resources found in MongoDB.

The problem is that the rsmetrics calculations checks if the resources are within the given datetime range for computations. However, since those large datasets are retrieved on best-effort their timestamp might not be within that particular datetime range.

Therefore, as a solution, a new parameter is introduced `--ignore-timestamp` in order to ignore that timestamp check.

Usage Example:
```Bash
./rsmetrics.py -p online_engine -s $(date +"%Y-%m-01") -e $(date +"%Y-%m-%d") -t "$(date +"%B %Y")" --use-cache --ignore-timestamp
```