### PR TITLE
REC-289 Add Athena support in rs-stream.py

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@
 providers:
    - name: marketplace_rs
      db: "mongodb://localhost:27017/recommender_dev"
-   - name: athena
+   - name: content-based engine
      db: "mongodb://localhost:27017/athena_dev"
    - name: online_engine
      db: ""
@@ -23,6 +23,6 @@ service:
     # and also in metrics calculations where service is considered
     published: true
     category:
-       athena: [service]
+       content-based engine: [service]
        marketplace_rs: [service]
        online_engine: [training, data_source]

--- a/rs-stream.py
+++ b/rs-stream.py
@@ -14,7 +14,8 @@ from datetime import datetime
 # mapping recommendations
 rec_map = {'publications': 'publication', 'datasets': 'dataset',
            'software': 'software', 'services': 'service',
-           'trainings': 'training', 'other_research_product': 'other'}
+           'trainings': 'training', 'other_research_product': 'other',
+           'similar_services': 'service'}
 
 # Streaming connector using stomp protocol to ingest data from rs databus
 


### PR DESCRIPTION
This PR adds the ability to listen to recommendations provided by the Content-based Engine (Athena).